### PR TITLE
Alright these small changes will make all merger type values string w…

### DIFF
--- a/bin/runFixedPop
+++ b/bin/runFixedPop
@@ -155,6 +155,7 @@ if __name__ == '__main__':
     BSEDict = dictionary['bse']
     seed_int = int(dictionary['rand_seed']['seed'])
     filters = dictionary['filters']
+    filters['merger_type'] = [str(i).zfill(4) for i in filters['merger_type']]
     convergence = dictionary['convergence']
 
     if seed_int != 0:

--- a/cosmic/evolve.py
+++ b/cosmic/evolve.py
@@ -150,4 +150,7 @@ class Evolve(Table):
                            columns=bcm_columns,
                            index=bcm_arrays[:, -1].astype(int))
 
+        bcm.merger_type = bcm.merger_type.astype(int).astype(str).apply(lambda x: x.zfill(4))
+        bcm.bin_state = bcm.bin_state.astype(int)
+
         return bpp, bcm, initialbinarytable 

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -4,14 +4,18 @@
 ; False == throw away binaries
 mass_transfer_white_dwarf_to_co = False
 select_final_state = True
-; 0 alive today, 1 merged, 2 disrupted, 3 no remnant left after SN
-binary_state = [0,1,2,3]
+; 0 alive today, 1 merged, 2 disrupted
+binary_state = [1]
+; type of mergers you want. it goes by the logic
+; kstar1kstar2 so like 1313 for NSNS or 1414 for BHBH
+; value of -1 is default for alive today or disrupted
+merger_type = [1313, 1314, 1413, 1414]
 ;porb_above_1e4 = False
 ;LISA_sources = False
 
 [convergence]
 ; perform convergence over selected region
-LISA_convergence=True
+LISA_convergence=False
 
 [rand_seed]
 ; random seed int


### PR DESCRIPTION
…ith a consitent length of 4 so that we can have merger_type 0101 and 1313 and 0213 etc in a unified (string) way. In addiiton I updated Params.ini to reflect how filtering can bedone through the ini file, a small change was needed in runFixedPop to correct format the merger_type row from the inifile so it can still be used