### PR TITLE
Convergence fix

### DIFF
--- a/bin/runFixedPop
+++ b/bin/runFixedPop
@@ -28,7 +28,7 @@ import json
 import numpy as np
 import scipy.special as ss
 import pandas as pd
-
+import warnings
 
 from cosmic.sample.initialbinarytable import InitialBinaryTable
 from cosmic import Match
@@ -254,8 +254,10 @@ if __name__ == '__main__':
         bpp, bcm, initCond = Evolve.evolve(initialbinarytable=IBT, BSEDict=BSEDict, nproc=args.nproc, idx=idx, dtp=dtp)
 
         # Convert the orbital period from years to log seconds
-        bcm['porb'] = np.log10(bcm['porb']*sec_in_year)
-        bpp['porb'] = np.log10(bpp['porb']*sec_in_year)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="divide by zero encountered in log10")
+            bcm['porb'] = np.log10(bcm['porb']*sec_in_year)
+            bpp['porb'] = np.log10(bpp['porb']*sec_in_year)
         
         # Keep track of the index
         idx = int(bcm.bin_num.max()+1)

--- a/cosmic/Match.py
+++ b/cosmic/Match.py
@@ -22,6 +22,7 @@
 import numpy as np
 import pandas as pd
 import astropy.stats as astroStats
+import warnings
 from cosmic.utils import param_transform, filter_bpp_bcm, bcm_conv_select
 
 
@@ -52,8 +53,13 @@ def match(dataCm):
     histoBinEdges = [[], []]
     # COMPUTE THE BINWIDTH FOR THE MOST COMPLETE DATA SET:
     # NOTE: THIS WILL BE THE BINWIDTH FOR ALL THE HISTOGRAMS IN THE HISTO LIST
-    mainHisto, binEdges = astroStats.histogram(np.array(dataCm[0]), bins='knuth')
-    
+    with warnings.catch_warnings():
+        #warnings.filterwarnings("ignore", message="divide by zero encountered in divide")
+        warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
+        try:
+            mainHisto, binEdges = astroStats.histogram(np.array(dataCm[0]), bins='knuth')
+        except:
+            mainHisto, binEdges = astroStats.histogram(np.array(dataCm[0]), bins='scott')
     # BIN THE DATA:
     for i in range(2):
         histo[i], histoBinEdges[i] = astroStats.histogram(dataCm[i], bins = binEdges, density = True)


### PR DESCRIPTION
Fixing issue: [#120](https://github.com/COSMIC-PopSynth/COSMIC/issues/120) pointed out by @michaelzevin 

This now tries to use knuth binwidths; and if it can't, uses Scott binwidth. It also catches a warning that gets thrown when log10(0) is calculated for porb=0 sources.