### PR TITLE
Convergence fix

### DIFF
--- a/cosmic/Match.py
+++ b/cosmic/Match.py
@@ -54,12 +54,15 @@ def match(dataCm):
     # COMPUTE THE BINWIDTH FOR THE MOST COMPLETE DATA SET:
     # NOTE: THIS WILL BE THE BINWIDTH FOR ALL THE HISTOGRAMS IN THE HISTO LIST
     with warnings.catch_warnings():
-        #warnings.filterwarnings("ignore", message="divide by zero encountered in divide")
         warnings.filterwarnings("ignore", message="divide by zero encountered in double_scalars")
         try:
-            mainHisto, binEdges = astroStats.histogram(np.array(dataCm[0]), bins='knuth')
+            bw, binEdges = astroStats.knuth_bin_width(np.array(dataCm[0]), return_bins=True)
         except:
-            mainHisto, binEdges = astroStats.histogram(np.array(dataCm[0]), bins='scott')
+            bw, binEdges = astroStats.scott_bin_width(np.array(dataCm[0]), return_bins=True)
+    if bw < 1e-4:
+        bw = 1e-4
+        binEdges = np.arange(binEdges[0], binEdges[-1], bw)
+
     # BIN THE DATA:
     for i in range(2):
         histo[i], histoBinEdges[i] = astroStats.histogram(dataCm[i], bins = binEdges, density = True)

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -93,8 +93,6 @@ def filter_bpp_bcm(bcm, bpp, method, kstar1_range, kstar2_range):
                                               (bcm_2.kstar_2.isin(kstar2_range))].bin_num.tolist())              
             bcm = bcm.loc[bcm.bin_num.isin(bin_num_save)]  
               
-        elif (meth == 'merger_type'):
-            bcm = bcm.loc[bcm.merger_type.isin(use)]
         elif (meth == 'LISA_sources') and use:
             if 0 in method['binary_state']:
                 bcm_0 = bcm.loc[bcm.bin_state==0]

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -7,10 +7,6 @@ mass_transfer_white_dwarf_to_co = False
 select_final_state = True
 ; 0 alive today, 1 merged, 2 disrupted
 binary_state = [1]
-; type of mergers you want. it goes by the logic
-; kstar1kstar2 so like 1313 for NSNS or 1414 for BHBH
-; value of -1 is default for alive today or disrupted
-merger_type = [1313, 1314, 1413, 1414]
 ; filter out all binaries with Porb > 1e5 seconds
 LISA_sources = False
 


### PR DESCRIPTION
Ok- I had to reopen this bad boy because @michaelzevin pointed out an issue: https://github.com/COSMIC-PopSynth/COSMIC/issues/120 that needed to be fixed. This was caused by the binwidths getting to be tiny (1-e7) which is not good. Now the binwidth for the convergence histogram has a minimum of 1e-4.

I also removed the merger_type filter since it is now redundant with the bin_state filter.