### PR TITLE
remove merger flag

### DIFF
--- a/cosmic/evolve.py
+++ b/cosmic/evolve.py
@@ -145,8 +145,6 @@ class Evolve(Table):
             initialbinarytable['bconst'] = BSEDict['bconst']
         if 'ck' not in initialbinarytable.keys():
             initialbinarytable['ck'] = BSEDict['ck']
-        if 'merger' not in initialbinarytable.keys():
-            initialbinarytable['merger'] = BSEDict['merger']
         if 'windflag' not in initialbinarytable.keys():
             initialbinarytable['windflag'] = BSEDict['windflag']
         if 'dtp' not in initialbinarytable.keys():
@@ -183,7 +181,7 @@ class Evolve(Table):
                                                 'ecsnp', 'ecsn_mlow', 'aic', 'sigma', 'sigmadiv', 'bhsigmafrac', 'polar_kick_angle',
                                                 'natal_kick_array', 'qcrit_array',
                                                 'beta', 'xi', 'acc2', 'epsnov',
-                                                'eddfac', 'gamma', 'bconst', 'ck', 'merger', 'windflag', 'dtp',
+                                                'eddfac', 'gamma', 'bconst', 'ck', 'windflag', 'dtp',
                                                 'randomseed', 'bin_num']].values
 
         initial_binary_table_column_names = ['kstar_1', 'kstar_2', 'mass1_binary', 'mass2_binary', 'porb', 'ecc',
@@ -193,7 +191,7 @@ class Evolve(Table):
                                              'mxns', 'pts1', 'pts2', 'pts3',
                                              'ecsnp', 'ecsn_mlow', 'aic', 'sigma', 'sigmadiv', 'bhsigmafrac', 'polar_kick_angle',
                                              'beta', 'xi', 'acc2', 'epsnov',
-                                             'eddfac', 'gamma', 'bconst', 'ck', 'merger', 'windflag', 'dtp',
+                                             'eddfac', 'gamma', 'bconst', 'ck', 'windflag', 'dtp',
                                              'randomseed', 'bin_num']
 
         initial_binary_table_column_names.extend(natal_kick_columns)
@@ -209,7 +207,7 @@ class Evolve(Table):
                                                f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17], f[18], f[19],
                                                f[20], f[21], f[22], f[23], f[24], f[25], f[26], f[27], f[28], f[29],
                                                f[30], f[31], f[32], f[33], f[34], f[35], f[36], f[37], f[38], f[39],
-                                               f[40], f[41], f[42], f[43], f[44], f[45], f[46], f[47])
+                                               f[40], f[41], f[42], f[43], f[44], f[45], f[46])
 
                 try:
                     bpp = bpp[:np.argwhere(bpp[:,0] == -1)[0][0]]
@@ -220,8 +218,8 @@ class Evolve(Table):
                     raise Warning('bpp overload: mass1 = {0}, mass2 = {1}, porb = {2}, ecc = {3}, tphysf = {4}, metallicity = {5}'\
                                    .format(f[2], f[3], f[4], f[5], f[7], f[6]))
 
-                bpp_bin_numbers = np.atleast_2d(np.array([f[48]] * len(bpp))).T
-                bcm_bin_numbers = np.atleast_2d(np.array([f[48]] * len(bcm))).T
+                bpp_bin_numbers = np.atleast_2d(np.array([f[47]] * len(bpp))).T
+                bcm_bin_numbers = np.atleast_2d(np.array([f[47]] * len(bcm))).T
 
                 bpp = np.hstack((bpp, bpp_bin_numbers))
                 bcm = np.hstack((bcm, bcm_bin_numbers))

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -8,7 +8,7 @@
      \ sigmatmp,sigmadivtmp,bhsigmafractmp,polar_kick_angletmp,
      \ natal_kick_array,qcrit_array,betatmp,xitmp,
      \ acc2tmp,epsnovtmp,eddfactmp,gammatmp,
-     \ bconsttmp,CKtmp,mergertmp,windflagtmp,dtptmp,idumtmp,
+     \ bconsttmp,CKtmp,windflagtmp,dtptmp,idumtmp,
      \ bppout,bcmout)
       implicit none
       INCLUDE 'const_bse.h'
@@ -221,7 +221,7 @@
       REAL*8 sigmatmp,bhsigmafractmp,polar_kick_angletmp,betatmp,xitmp
       REAL*8 ecsnptmp,ecsn_mlowtmp,sigmadivtmp
       REAL*8 acc2tmp,epsnovtmp,eddfactmp,gammatmp
-      REAL*8 bconsttmp,CKtmp,mergertmp,qc_fixed,qcrit_array(16)
+      REAL*8 bconsttmp,CKtmp,qc_fixed,qcrit_array(16)
       REAL*8 vk1_bcm,vk2_bcm,vsys_bcm,theta_bcm,natal_kick_array(6)
       INTEGER cekickflagtmp,cemergeflagtmp,cehestarflagtmp
       INTEGER ceflagtmp,tflagtmp,ifflagtmp,nsflagtmp,aictmp
@@ -264,7 +264,6 @@ Cf2py intent(out) bppout,bcmout
       gamma = gammatmp
       bconst = bconsttmp
       CK = CKtmp
-      merger = mergertmp
       windflag = windflagtmp
       dtp = dtptmp
       idum = idumtmp
@@ -325,6 +324,7 @@ Cf2py intent(out) bppout,bcmout
       diskxip = 0.d0 !sets if diskxi is to be used (>0; 0.01) and is min diskxi value.
       formation(1) = 0 !helps determine formation channel of interesting systems.
       formation(2) = 0
+      merger = -1 !used in CMC to track systems that dynamically merge
       notamerger = 0 !if 0 you reset the merger NS product to new factory settings else you don't.
       mergemsp = 1 !if set to 1 any NS that merges with another star where the NS is an MSP stays an MSP...
       merge_mem = 0

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -69,7 +69,7 @@ with `Rodriguez+2018 <http://adsabs.harvard.edu/abs/2018PhRvL.120o1101R>`_ and `
 
 .. ipython::
 
-    In [5]: BSEDict = {'xi': 0.5, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 0, 'alpha1': 1.0, 'pts1': 0.001, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 1.0, 'ck': -1000, 'bwind': 0.0, 'lambdaf': 1.0, 'mxns': 3.0, 'beta': -1.0, 'tflag': 1, 'acc2': 1.5, 'nsflag': 3, 'ceflag': 0, 'eddfac': 1.0, 'merger': 0, 'ifflag': 0, 'bconst': -3000, 'sigma': 265.0, 'gamma': -2.0, 'ppsn': 1, 'natal_kick_array' : [-100.0,-100.0,-100.0,-100.0,-100.0,-100.0], 'bhsigmafrac' : 1.0, 'polar_kick_angle' : 90, 'qcrit_array' : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0], 'cekickflag' : 0, 'cehestarflag' : 0, 'cemergeflag' : 0, 'ecsnp' : 2.5, 'ecsn_mlow' : 1.6, 'aic' : 1, 'sigmadiv' :-20.0}
+    In [5]: BSEDict = {'xi': 0.5, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 0, 'alpha1': 1.0, 'pts1': 0.001, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 1.0, 'ck': -1000, 'bwind': 0.0, 'lambdaf': 1.0, 'mxns': 3.0, 'beta': -1.0, 'tflag': 1, 'acc2': 1.5, 'nsflag': 3, 'ceflag': 0, 'eddfac': 1.0, 'ifflag': 0, 'bconst': -3000, 'sigma': 265.0, 'gamma': -2.0, 'ppsn': 1, 'natal_kick_array' : [-100.0,-100.0,-100.0,-100.0,-100.0,-100.0], 'bhsigmafrac' : 1.0, 'polar_kick_angle' : 90, 'qcrit_array' : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0], 'cekickflag' : 0, 'cehestarflag' : 0, 'cemergeflag' : 0, 'ecsnp' : 2.5, 'ecsn_mlow' : 1.6, 'aic' : 1, 'sigmadiv' :-20.0}
 
 Once the binary is initialized and the BSE model is set, the system is evolved with the 
 the Evolve class, which calls the evolv2.f subroutine in the BSE source code. 

--- a/docs/runpop/index.rst
+++ b/docs/runpop/index.rst
@@ -143,7 +143,7 @@ The syntax for the Evolve class is as follows:
 
     In [2]: from cosmic.evolve import Evolve   
 
-    In [4]: BSEDict = {'xi': 0.5, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 0, 'alpha1': 1.0, 'pts1': 0.05, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 1.0, 'ck': -1000, 'bwind': 0.0, 'lambdaf': 1.0, 'mxns': 3.0, 'beta': -1.0, 'tflag': 1, 'acc2': 1.5, 'nsflag': 3, 'ceflag': 0, 'eddfac': 1.0, 'merger': 0, 'ifflag': 0, 'bconst': -3000, 'sigma': 265.0, 'gamma': -2.0, 'ppsn': 1, 'natal_kick_array' :[-100.0,-100.0,-100.0,-100.0,-100.0,-100.0], 'bhsigmafrac' : 1.0, 'polar_kick_angle' : 90, 'qcrit_array' : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0], 'cekickflag' : 0, 'cehestarflag' : 0, 'cemergeflag' : 0, 'ecsnp' : 2.5, 'ecsn_mlow' : 1.6, 'aic' : 1, 'sigmadiv' :-20.0}
+    In [4]: BSEDict = {'xi': 0.5, 'bhflag': 1, 'neta': 0.5, 'windflag': 3, 'wdflag': 0, 'alpha1': 1.0, 'pts1': 0.05, 'pts3': 0.02, 'pts2': 0.01, 'epsnov': 0.001, 'hewind': 1.0, 'ck': -1000, 'bwind': 0.0, 'lambdaf': 1.0, 'mxns': 3.0, 'beta': -1.0, 'tflag': 1, 'acc2': 1.5, 'nsflag': 3, 'ceflag': 0, 'eddfac': 1.0, 'ifflag': 0, 'bconst': -3000, 'sigma': 265.0, 'gamma': -2.0, 'ppsn': 1, 'natal_kick_array' :[-100.0,-100.0,-100.0,-100.0,-100.0,-100.0], 'bhsigmafrac' : 1.0, 'polar_kick_angle' : 90, 'qcrit_array' : [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0], 'cekickflag' : 0, 'cehestarflag' : 0, 'cemergeflag' : 0, 'ecsnp' : 2.5, 'ecsn_mlow' : 1.6, 'aic' : 1, 'sigmadiv' :-20.0}
 
     In [5]: bpp, bcm, initC  = Evolve.evolve(initialbinarytable=InitialBinaries, BSEDict=BSEDict)
 


### PR DESCRIPTION
removed merger flag from inputs, now it just gets set at the beginning of evolv2.f to its default value of -1. it still gets used in CMCpass, since we're not sure if it will alter CMC stuff. 