### PR TITLE
Ecsn

### DIFF
--- a/cosmic/src/comenv.f
+++ b/cosmic/src/comenv.f
@@ -38,7 +38,7 @@
       REAL*8 bkick(20),fallback,ecsn,ecsn_mlow,M1i,M2i
       common /fall/fallback
       INTEGER formation1,formation2
-      REAL*8 sigmahold,sigmadiv
+      REAL*8 sigmahold
       REAL*8 AURSUN,K3
       PARAMETER (AURSUN = 214.95D0,K3 = 0.21D0)
       LOGICAL COEL,output
@@ -52,7 +52,6 @@
       TWOPI = 2.D0*ACOS(-1.D0)
       COEL = .FALSE.
       sigmahold = sigma
-      sigmadiv = -20.d0
       snp = 0
       output = .false.
 *

--- a/cosmic/src/const_bse.h
+++ b/cosmic/src/const_bse.h
@@ -19,9 +19,9 @@
       COMMON /CEVARS/ alpha1,lambda
       REAL*8 bconst,CK
       COMMON /MAGVARS/ bconst,CK
-      REAL*8 sigma,bhsigmafrac,pisn
+      REAL*8 sigma,sigmadiv,bhsigmafrac,pisn
       REAL*8 polar_kick_angle,mu_SN1,omega_SN1
-      COMMON /SNVARS/ sigma,bhsigmafrac,pisn
+      COMMON /SNVARS/ sigma,sigmadiv,bhsigmafrac,pisn
       COMMON /SNVARS/ polar_kick_angle,mu_SN1,omega_SN1
 *
       INTEGER*8 id1_pass,id2_pass

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -189,7 +189,7 @@
 *
       INTEGER pulsar,bdecayfac,aic,htpmb,ST_cr,ST_tide,wdwdedd,eddlim
       INTEGER mergemsp,merge_mem,notamerger,binstate,mergertype
-      REAL*8 fallback,sigmahold,sigmadiv,ecsn,ecsn_mlow
+      REAL*8 fallback,sigmahold,ecsn,ecsn_mlow
       REAL*8 vk,u1,u2,s,Kconst,betahold,convradcomp(2),teff(2)
       REAL*8 B_0(2),bacc(2),tacc(2),xip,xihold,diskxip
       REAL*8 deltam1_bcm,deltam2_bcm,b01_bcm,b02_bcm

--- a/cosmic/src/kick.f
+++ b/cosmic/src/kick.f
@@ -58,7 +58,7 @@
       real*8 signs,sigc,psins,psic,cpsins,spsins,cpsic,spsic
       real*8 csigns
       real*8 semilatrec,cangleofdeath,angleofdeath,energy
-      real*8 fallback,kickscale,bound
+      real*8 fallback,bound
 * Output
       real*8 v1xout,v1yout,v1zout,vkout1,vkout2
       real*8 v2xout,v2yout,v2zout
@@ -83,13 +83,9 @@
       vkout1 = 0.d0
       vkout2 = 0.d0
 
-* Scaling owing to ECSN.
-      kickscale = 0.d0
-*
-*
+* sigma is negative for ECSN
       if(sigma.lt.0.d0)then
          sigma = -1.d0*sigma
-         kickscale = 10.d0
       endif
       sigmah = sigma
 *Test: Checking if we can make customized sigma for blackholes only
@@ -192,10 +188,6 @@
 *          if(kw.eq.14)then
 * Limit BH kick with fallback only if wanted
 *          write(20,*)'BH FORM', m1,vk,fallback,kw
-          if(kickscale.gt.0.d0)then
-             vk = vk/kickscale
-             vk2 = vk2/kickscale/kickscale
-          endif
           if(kw.eq.14.and.bhflag.eq.0)then
              vk2 = 0.d0
              vk = 0.d0


### PR DESCRIPTION
This is fixing a couple of small bugs related to the ECSN flags.

1 - sigmadiv was hard coded in comenv, so I moved it to the const_bse.h file 
3 - kickscale was still working to scale any kicks for which sigmadiv>0.