### PR TITLE
PISN bug

### DIFF
--- a/cosmic/src/comenv.f
+++ b/cosmic/src/comenv.f
@@ -61,7 +61,7 @@
       CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
       CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
      &            R1,L1,KW1,MC1,RC1,MENV,RENV,K21,ST_tide,
-     &            ecsn,ecsn_mlow)
+     &            ecsn,ecsn_mlow,1)
       OSPIN1 = JSPIN1/(K21*R1*R1*(M1-MC1)+K3*RC1*RC1*MC1)
       MENVD = MENV/(M1-MC1)
       RZAMS = RZAMSF(M01)
@@ -78,7 +78,7 @@
       CALL star(KW2,M02,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS)
       CALL hrdiag(M02,AJ2,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS,
      &            R2,L2,KW2,MC2,RC2,MENV,RENV,K22,ST_tide,
-     &            ecsn,ecsn_mlow)
+     &            ecsn,ecsn_mlow,2)
       OSPIN2 = JSPIN2/(K22*R2*R2*(M2-MC2)+K3*RC2*RC2*MC2)
 *
 * Calculate the binding energy of the giant envelope (multiplied by lambda).
@@ -191,7 +191,7 @@
             CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
             CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
      &                  R1,L1,KW1,MC1,RC1,MENV,RENV,K21,ST_tide,
-     &                  ecsn,ecsn_mlow)
+     &                  ecsn,ecsn_mlow,1)
             IF(KW1.GE.13)THEN
                formation1 = 4
                if(KW1.eq.13.and.ecsn.gt.0.d0)then
@@ -412,7 +412,7 @@
             CALL star(KW1,M01,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS)
             CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
      &                  R1,L1,KW1,MC1,RC1,MENV,RENV,K21,ST_tide,
-     &                  ecsn,ecsn_mlow)
+     &                  ecsn,ecsn_mlow,1)
             IF(KW1.GE.13)THEN
                formation1 = 4
                if(KW1.eq.13.and.ecsn.gt.0.d0)then
@@ -508,7 +508,7 @@
             CALL star(KW2,M02,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS)
             CALL hrdiag(M02,AJ2,M2,TM2,TN,TSCLS2,LUMS,GB,ZPARS,
      &                  R2,L2,KW2,MC2,RC2,MENV,RENV,K22,ST_tide,
-     &                  ecsn,ecsn_mlow)
+     &                  ecsn,ecsn_mlow,2)
             IF(KW2.GE.13.AND.KW.LT.13)THEN
                formation2 = 4
                if(KW2.eq.13.and.ecsn.gt.0.d0)then
@@ -672,7 +672,7 @@
          M1i = M1
          CALL hrdiag(M01,AJ1,M1,TM1,TN,TSCLS1,LUMS,GB,ZPARS,
      &               R1,L1,KW,MC1,RC1,MENV,RENV,K21,ST_tide,
-     &               ecsn,ecsn_mlow)
+     &               ecsn,ecsn_mlow,1)
          if(output) write(*,*)'coel 2 5:',KW,M1,M01,R1,MENV,RENV
          IF(KW1i.LE.12.and.KW.GE.13)THEN
             formation1 = 4

--- a/cosmic/src/const_bse.h
+++ b/cosmic/src/const_bse.h
@@ -11,6 +11,8 @@
       COMMON /FLAGS/ tflag,ifflag,nsflag,wdflag,bhflag,windflag
       INTEGER ceflag,cekickflag,cemergeflag,cehestarflag,ussn
       COMMON /CEFLAGS/ ceflag,cekickflag,cemergeflag,cehestarflag,ussn
+      INTEGER pisn_track(2)
+      COMMON /TRACKERS/ pisn_track
 *
       REAL*8 neta,bwind,hewind,mxns,beta,xi,acc2,epsnov,eddfac,gamma
       COMMON /WINDVARS/ neta,bwind,hewind,mxns,beta,xi,acc2,epsnov

--- a/cosmic/src/evolv1.f
+++ b/cosmic/src/evolv1.f
@@ -174,7 +174,7 @@ c-------------------------------------------------------------c
 * given the initial mass, current mass, metallicity and age
          kwold = kw
          CALL hrdiag(mass,aj,mt,tm,tn,tscls,lums,GB,zpars,
-     &               r,lum,kw,mc,rc,menv,renv,k2)
+     &               r,lum,kw,mc,rc,menv,renv,k2,1)
 *
 * If mass loss has occurred and no type change then check that we
 * have indeed limited the radius change to 10%.
@@ -220,7 +220,7 @@ c-------------------------------------------------------------c
                mc = mc1
                CALL star(kw,mass,mt,tm,tn,tscls,lums,GB,zpars)
                CALL hrdiag(mass,aj,mt,tm,tn,tscls,lums,GB,zpars,
-     &                     r,lum,kw,mc,rc,menv,renv,k2)
+     &                     r,lum,kw,mc,rc,menv,renv,k2,1)
                goto 20
             endif
  30         continue
@@ -316,7 +316,7 @@ c-------------------------------------------------------------c
             aj = MAX(aj,aj*(1.d0-eps)+dtr)
             mc1 = mc 
             CALL hrdiag(mass,aj,mt,tm,tn,tscls,lums,GB,zpars,
-     &                  r1,lum1,kw,mc1,rc1,menv1,renv1,k21)
+     &                  r1,lum1,kw,mc1,rc1,menv1,renv1,k21,1)
             dr = r1 - rm0
             if(ABS(dr).gt.0.1d0*rm0)then
                dtm = dtr - ajhold*eps
@@ -336,7 +336,7 @@ c-------------------------------------------------------------c
  40      aj = ajhold + dtm
          mc1 = mc 
          CALL hrdiag(mass,aj,mt,tm,tn,tscls,lums,GB,zpars,
-     &               r1,lum1,kw,mc1,rc1,menv1,renv1,k21)
+     &               r1,lum1,kw,mc1,rc1,menv1,renv1,k21,1)
          dr = r1 - rm0
          it = it + 1
          if(it.eq.20.and.kw.eq.4) goto 50

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -325,6 +325,9 @@ Cf2py intent(out) bppout,bcmout
       diskxip = 0.d0 !sets if diskxi is to be used (>0; 0.01) and is min diskxi value.
       formation(1) = 0 !helps determine formation channel of interesting systems.
       formation(2) = 0
+      pisn_track(1) = 0 !tracks whether a PISN occurred for each
+component.
+      pisn_track(2) = 0
       merger = -1 !used in CMC to track systems that dynamically merge
       notamerger = 0 !if 0 you reset the merger NS product to new factory settings else you don't.
       mergemsp = 1 !if set to 1 any NS that merges with another star where the NS is an MSP stays an MSP...
@@ -478,7 +481,7 @@ Cf2py intent(out) bppout,bcmout
          CALL star(kstar(k),mass0(k),mass(k),tm,tn,tscls,lums,GB,zpars)
          CALL hrdiag(mass0(k),age,mass(k),tm,tn,tscls,lums,GB,zpars,
      &               rm,lum,kstar(k),mc,rc,me,re,k2,ST_tide,
-     &               ecsn,ecsn_mlow)
+     &               ecsn,ecsn_mlow,k)
          aj(k) = age
          epoch(k) = tphys - age
          rad(k) = rm
@@ -1259,7 +1262,7 @@ Cf2py intent(out) bppout,bcmout
          CALL star(kw,m0,mt,tm,tn,tscls,lums,GB,zpars)
          CALL hrdiag(m0,age,mt,tm,tn,tscls,lums,GB,zpars,
      &               rm,lum,kw,mc,rc,me,re,k2,ST_tide,
-     &               ecsn,ecsn_mlow)
+     &               ecsn,ecsn_mlow,k)
 *
          if(kw.ne.15)then
             ospin(k) = jspin(k)/(k2*(mt-mc)*rm*rm+k3*mc*rc*rc)
@@ -1615,6 +1618,9 @@ Cf2py intent(out) bppout,bcmout
             rrl2 = rad(2)/rol(2)
             deltam1_bcm = dmt(1) - dmr(1)
             deltam2_bcm = dmt(2) - dmr(2)
+* Check if PISN occurred, and if so overwrite formation
+            if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
+            if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
             CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
      &                    lumin(1),rad(1),teff1,massc(1),
      &                    radc(1),menv(1),renv(1),epoch(1),
@@ -1833,6 +1839,9 @@ Cf2py intent(out) bppout,bcmout
           rrl2 = rad(2)/rol(2)
           deltam1_bcm = 0.0
           deltam2_bcm = 0.0
+* Check if PISN occurred, and if so overwrite formation
+          if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
+          if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
           CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
      &                  lumin(1),rad(1),teff1,massc(1),
      &                  radc(1),menv(1),renv(1),epoch(1),
@@ -2946,7 +2955,7 @@ Cf2py intent(out) bppout,bcmout
          kw = kstar(k)
          CALL star(kw,m0,mt,tm,tn,tscls,lums,GB,zpars)
          CALL hrdiag(m0,age,mt,tm,tn,tscls,lums,GB,zpars,
-     &               rm,lum,kw,mc,rc,me,re,k2,ST_tide,ecsn,ecsn_mlow)
+     &               rm,lum,kw,mc,rc,me,re,k2,ST_tide,ecsn,ecsn_mlow,k)
 *
 * Check for a supernova and correct the semi-major axis if so.
 *
@@ -3134,6 +3143,9 @@ Cf2py intent(out) bppout,bcmout
               deltam1_bcm = (dm2 - dms(1))/dt
               deltam2_bcm = (-1.0*dm1 - dms(2))/dt
           endif
+* Check if PISN occurred, and if so overwrite formation
+          if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
+          if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
           CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
      &                  lumin(1),rad(1),teff1,massc(1),
      &                  radc(1),menv(1),renv(1),epoch(1),
@@ -3483,6 +3495,9 @@ Cf2py intent(out) bppout,bcmout
               deltam1_bcm = (dm2 - dms(1))/dt
               deltam2_bcm = (-1.0*dm1 - dms(2))/dt
           endif
+* Check if PISN occurred, and if so overwrite formation
+          if(pisn_track(1).ne.0) formation(1) = pisn_track(1)
+          if(pisn_track(2).ne.0) formation(2) = pisn_track(2)
           CALL writebcm(ip,tphys,kstar(1),mass0(1),mass(1),
      &                  lumin(1),rad(1),teff1,massc(1),
      &                  radc(1),menv(1),renv(1),epoch(1),

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -795,12 +795,10 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Use NS/BH masses given by Belczynski+08. PK.
 *
                      !First calculate the proto-core mass
-                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn)then
+                     if(ecsn.gt.0.d0.and.mc.le.ecsn)then
                         mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mcbagb.le.2.25d0)then !this should be ecsn, unless ecsn=0
-*                     if(mcbagb.le.2.35d0)then
+                     elseif(ecsn.eq.0.d0.and.mc.le.2.25d0)then !this should be ecsn, unless ecsn=0
                         mcx = 1.38d0
-*                     elseif(mc.lt.4.29d0)then
                      elseif(mc.lt.4.82d0)then
                         mcx = 1.5d0
                      elseif(mc.ge.4.82d0.and.mc.lt.6.31d0)then
@@ -827,9 +825,9 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 *
 *                    For this, we just set the proto-core mass to one
                      mcx = 1.d0
-                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn)then
+                     if(ecsn.gt.0.d0.and.mc.le.ecsn)then
                         mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mcbagb.le.2.25d0)then !this should be ecsn, unless ecsn=0
+                     elseif(ecsn.eq.0.d0.and.mc.le.2.25d0)then !this should be ecsn, unless ecsn=0
                         mcx = 1.38d0
                      endif
                      if(mc.le.2.5d0)then
@@ -899,56 +897,17 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Belczynski+2016 prescription: just shrink any BH with a He core mass
 * between 45 and 65 solar masses, and blow up anything between 65 and
 * 135 solar masses.  Cheap, but effective
-                     if(pisn.eq.1)then
-                        if(mcbagb.ge.45.d0.and.mcbagb.lt.65.d0)then
-                           mt = 45.d0
-                           mc = 45.d0
-                        elseif(mcbagb.ge.65.d0.and.mcbagb.lt.135.d0)then
+                     if(pisn.gt.0)then
+                        if(mc.ge.pisn.and.mc.lt.65.d0)then
+                           mt = pisn
+                           mc = pisn
+                        elseif(mc.ge.65.d0.and.mc.lt.135.d0)then
                            mt = 0.d0
                            mc = 0.d0
                            kw = 15
                         endif
-* The Spera+Mapelli2017 prescription is a tad more sophisticated:
-* complex fitting formula to Stan Woosley's PSN models.  HOWEVER, these
-* were done using the ZAMS mass/core mass/remnant mass relationships for
-* SEVN, not BSE.  In other words, I woud be careful using this (and in
-* practice, it doesn't vary that much from Belczynski's prescription,
-* since the He core masses are the same in both)
-
-                     elseif(pisn.eq.2)then
-                        frac = mcbagb/mt
-                        kappa = 0.67d0*frac + 0.1d0
-                        sappa = 0.5228d0*frac - 0.52974
-                        if(mcbagb.le.32.d0)then
-                           alphap = 1.0d0
-                        elseif(frac.lt.0.9d0.and.mcbagb.le.37.d0)then
-                           alphap = 0.2d0*(kappa-1.d0)*mcbagb +
-     &                              0.2d0*(37.d0 - 32.d0*kappa)
-                        elseif(mcbagb.le.60d0.and.frac.lt.0.9d0)then
-                           alphap = kappa
-                        elseif(frac.ge.0.9.and.mcbagb.le.37d0)then
-                           alphap = sappa*(mcbagb - 32.d0) + 1.d0
-                        elseif(frac.ge.0.9.and.mcbagb.le.56.and.
-     &                        sappa.lt.0.82916)then
-                           alphap = 5.d0*sappa + 1.d0
-                        elseif(frac.ge.0.9.and.mcbagb.le.56.and.
-     &                        sappa.ge.0.82916)then
-                           alphap = (-0.1381*frac + 0.1309)*
-     &                              (mcbagb - 56.d0) + 0.82916
-                        elseif(frac.ge.0.9.and.mcbagb.gt.56.and.
-     &                        mcbagb.lt.64)then
-                           alphap = -0.103645*mcbagb + 6.63328
-                        elseif(mcbagb.ge.64.and.mcbagb.lt.135)then
-                           alphap = 0.d0
-                           kw = 15
-                        elseif(mcbagb.ge.135)then
-                           alphap = 1.0d0
-                        endif
-
-                        mt = alphap*mt
+* Note that the Sprea+Mapelli2017 prescription is not for nake He stars
                      endif
-
-
 
 
 * Convert baryonic mass to gravitational mass (approx for BHs)

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -1,7 +1,7 @@
 ***
       SUBROUTINE hrdiag(mass,aj,mt,tm,tn,tscls,lums,GB,zpars,
      &                  r,lum,kw,mc,rc,menv,renv,k2,ST_tide,
-     &                  ecsn,ecsn_mlow)
+     &                  ecsn,ecsn_mlow,kidx)
       IMPLICIT NONE
       INCLUDE 'const_bse.h'
 *
@@ -23,7 +23,7 @@
 *       MS hook and more elaborate CHeB
 *
 *
-      integer kw,kwp
+      integer kw,kwp,kidx
       INTEGER ST_tide
 *
       real*8 mass,aj,mt,tm,tn,tscls(20),lums(10),GB(10),zpars(20)
@@ -639,10 +639,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                         if(mcbagb.ge.pisn.and.mcbagb.lt.65.d0)then
                            mt = pisn
                            mc = pisn
+                           pisn_track(kidx)=8
                         elseif(mcbagb.ge.65.d0.and.mcbagb.lt.135.d0)then
                            mt = 0.d0
                            mc = 0.d0
                            kw = 15
+                           pisn_track(kidx)=9
                         endif
 * The Spera+Mapelli2017 prescription is a tad more sophisticated:
 * complex fitting formula to Stan Woosley's PSN models.  HOWEVER, these
@@ -656,26 +658,34 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                         sappa = 0.5228d0*frac - 0.52974
                         if(mcbagb.le.32.d0)then
                            alphap = 1.0d0
+                           pisn_track(kidx)=8
                         elseif(frac.lt.0.9d0.and.mcbagb.le.37.d0)then
                            alphap = 0.2d0*(kappa-1.d0)*mcbagb +
      &                             0.2d0*(37.d0 - 32.d0*kappa)
+                           pisn_track(kidx)=8
                         elseif(mcbagb.le.60d0.and.frac.lt.0.9d0)then
                            alphap = kappa
+                           pisn_track(kidx)=8
                         elseif(frac.ge.0.9.and.mcbagb.le.37d0)then
                            alphap = sappa*(mcbagb - 32.d0) + 1.d0
+                           pisn_track(kidx)=8
                         elseif(frac.ge.0.9.and.mcbagb.le.56.and.
      &                         sappa.lt.0.82916)then
                            alphap = 5.d0*sappa + 1.d0
+                           pisn_track(kidx)=8
                         elseif(frac.ge.0.9.and.mcbagb.le.56.and.
      &                         sappa.ge.0.82916)then
                            alphap = (-0.1381*frac + 0.1309)*
      &                              (mcbagb - 56.d0) + 0.82916
+                           pisn_track(kidx)=8
                         elseif(frac.ge.0.9.and.mcbagb.gt.56.and.
      &                         mcbagb.lt.64)then
                            alphap = -0.103645*mcbagb + 6.63328
+                           pisn_track(kidx)=8
                         elseif(mcbagb.ge.64.and.mcbagb.lt.135)then
                            alphap = 0.d0
                            kw = 15
+                           pisn_track(kidx)=9
                         elseif(mcbagb.ge.135)then
                            alphap = 1.0d0
                         endif
@@ -901,10 +911,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                         if(mc.ge.pisn.and.mc.lt.65.d0)then
                            mt = pisn
                            mc = pisn
+                           pisn_track(kidx)=8
                         elseif(mc.ge.65.d0.and.mc.lt.135.d0)then
                            mt = 0.d0
                            mc = 0.d0
                            kw = 15
+                           pisn_track(kidx)=9
                         endif
 * Note that the Sprea+Mapelli2017 prescription is not for nake He stars
                      endif

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -640,7 +640,7 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                            mt = pisn
                            mc = pisn
                            pisn_track(kidx)=8
-                        elseif(mcbagb.ge.65.d0.and.mcbagb.lt.135.d0)then
+                        elseif(mcbagb.ge.65.d0.and.mcbagb.lt.125.d0)then
                            mt = 0.d0
                            mc = 0.d0
                            kw = 15
@@ -912,7 +912,7 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                            mt = pisn
                            mc = pisn
                            pisn_track(kidx)=8
-                        elseif(mc.ge.65.d0.and.mc.lt.135.d0)then
+                        elseif(mc.ge.65.d0.and.mc.lt.125.d0)then
                            mt = 0.d0
                            mc = 0.d0
                            kw = 15


### PR DESCRIPTION
This PR is regarding #202 #164. First of all, a bug was fixed for naked He stars, where it was still using the mcbagb variable to check whether the system underwent a PISN. Second, we now use SN_1/2=8 and SN_1/2=9 (formation1 and formation2 in the fortran code) to indicate when systems went through PPISN and PISN, respectively. We've also changed the PISN flag to set the maximum core mass (lower-end of the PISN gap) with positive numbers, use the Spera&Mapelli formalism when pisn=-1 (note has typos as of now because Mario miswrote a couple things, the summer student will be fixing it with my/Mario's guidance), and be turned off when pisn=0. 