### PR TITLE
Alright I have moved the logic to only write a final theta and system…

### DIFF
--- a/cosmic/src/bpp_array.f
+++ b/cosmic/src/bpp_array.f
@@ -106,8 +106,10 @@
         bcm(ip,34) = B_0_2
         bcm(ip,35) = SNkick_1
         bcm(ip,36) = SNkick_2
-        bcm(ip,37) = Vsys_final
-        bcm(ip,38) = SNtheta_final
+        if(bin_state.ne.2.d0)then
+            bcm(ip,37) = Vsys_final
+            bcm(ip,38) = SNtheta_final
+        endif
         bcm(ip,39) = float(SN_1)
         bcm(ip,40) = float(SN_2)
         bcm(ip,41) = bin_state

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1369,10 +1369,10 @@ Cf2py intent(out) bppout,bcmout
                if(bkick(14).gt.0.d0)then
                   vk2_bcm=bkick(14)
                endif
-               if(bkick(17).gt.0.d0.and.binstate.ne.2.d0)then
+               if(bkick(17).gt.0.d0)then
                   vsys_bcm=bkick(17)
                endif
-               if(bkick(20).gt.0.d0.and.binstate.ne.2.d0)then
+               if(bkick(20).gt.0.d0)then
                   theta_bcm=bkick(20)
                endif
 
@@ -1387,10 +1387,10 @@ Cf2py intent(out) bppout,bcmout
                if(bkick(14).gt.0.d0)then
                   vk2_bcm=bkick(14)
                endif
-               if(bkick(17).gt.0.d0.and.binstate.ne.2.d0)then
+               if(bkick(17).gt.0.d0)then
                   vsys_bcm=bkick(17)
                endif
-               if(bkick(20).gt.0.d0.and.binstate.ne.2.d0)then
+               if(bkick(20).gt.0.d0)then
                   theta_bcm=bkick(20)
                endif
                if(mass(3-k).lt.0.d0)then
@@ -2026,10 +2026,10 @@ Cf2py intent(out) bppout,bcmout
          if(bkick(14).gt.0.d0)then
              vk2_bcm=bkick(14)
          endif
-         if(bkick(17).gt.0.d0.and.binstate.ne.2.d0)then
+         if(bkick(17).gt.0.d0)then
              vsys_bcm=bkick(17)
          endif
-         if(bkick(20).gt.0.d0.and.binstate.ne.2.d0)then
+         if(bkick(20).gt.0.d0)then
              theta_bcm=bkick(20)
          endif
 *
@@ -3006,10 +3006,10 @@ Cf2py intent(out) bppout,bcmout
             if(bkick(14).gt.0.d0)then
                vk2_bcm=bkick(14)
             endif
-            if(bkick(17).gt.0.d0.and.binstate.ne.2.d0)then
+            if(bkick(17).gt.0.d0)then
                vsys_bcm=bkick(17)
             endif
-            if(bkick(20).gt.0.d0.and.binstate.ne.2.d0)then
+            if(bkick(20).gt.0.d0)then
                theta_bcm=bkick(20)
             endif
 
@@ -3279,10 +3279,10 @@ Cf2py intent(out) bppout,bcmout
       if(bkick(14).gt.0.d0)then
          vk2_bcm=bkick(14)
       endif
-      if(bkick(17).gt.0.d0.and.binstate.ne.2.d0)then
+      if(bkick(17).gt.0.d0)then
          vsys_bcm=bkick(17)
       endif
-      if(bkick(20).gt.0.d0.and.binstate.ne.2.d0)then
+      if(bkick(20).gt.0.d0)then
          theta_bcm=bkick(20)
       endif
 


### PR DESCRIPTION
…ic velcoity for systems taht either merged or are still alive, and not those that are disrupted, to the write bcm function. This is because sometimes binstate was set to 2 after the logic in evolv2 was done and therefore disrutped systems has final theta written to the BCM