### PR TITLE
we were cutting off CO WD progenitors

### DIFF
--- a/cosmic/tests/test_utils.py
+++ b/cosmic/tests/test_utils.py
@@ -46,7 +46,7 @@ BCM_TEST = pd.read_hdf(os.path.join(TEST_DATA_DIR, 'utils_test.hdf'), key='bcm')
 
 
 IDL_TABULATE_ANSWER = 0.5
-MASS_SUM_SINGLE = [41.0, 44.0, 50.0, 132.0, 320.0]
+MASS_SUM_SINGLE = [41.0, 41.6, 50.0, 132.0, 320.0]
 MASS_SUM_MULTIPLE = 301.0
 X_TRANS_SUM = -2.7199038e-07
 BW_KNUTH = 0.333

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -223,7 +223,7 @@ def mass_min_max_select(kstar_1, kstar_2):
         elif k == 12.0:
             min_mass[ii] = 5.0
         elif k == 11.0:
-            min_mass[ii] = 2.0
+            min_mass[ii] = 0.8
         elif k == 10.0:
             min_mass[ii] = 0.5
         ii += 1


### PR DESCRIPTION
I ran into this while getting together the LISA DWD models. CO WD progenitors can come from pretty low initial masses in binaries; especially if there is a stable mass transfer phase.