### PR TITLE
Quick concatkstars flag

### DIFF
--- a/cosmic/src/concatkstars.f
+++ b/cosmic/src/concatkstars.f
@@ -7,15 +7,22 @@
 *     Date :   11th December 2018
 *
       IMPLICIT NONE
+      INCLUDE 'const_bse.h'
 *
       INTEGER int1,int2,int3
       CHARACTER(len=2) str1,str2
       CHARACTER(len=4) str3
 
-      WRITE(str1,'(i2.2)') int1
-      WRITE(str2,'(i2.2)') int2
+      IF(USING_CMC.EQ.0)THEN
 
-      str3 = trim(adjustl(str1))//trim(adjustl(str2))
+          WRITE(str1,'(i2.2)') int1
+          WRITE(str2,'(i2.2)') int2
 
-      READ(str3,*)int3
+          str3 = trim(adjustl(str1))//trim(adjustl(str2))
+
+          READ(str3,*)int3
+      ELSE
+          int3 = -1
+      ENDIF
+
       END


### PR DESCRIPTION
Just a quick change to make it easier to compile CMC with multiple fortran/conda environments (and to not write random strings in CMC)