### PR TITLE
porb write bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
   - swig
   - libhdf5-serial-dev
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/cosmic/src/bpp_array.f
+++ b/cosmic/src/bpp_array.f
@@ -15,10 +15,11 @@
         REAL*8 bkick(20),mass1,mass2
         REAL*8 evolve_type,sep,tb,ecc,tphys,rrl1,rrl2
         REAL*8 aj1,aj2,tms1,tms2,massc1,massc2,rad1,rad2
+        REAL*8 tb_write,sep_cubed
         INTEGER jp,jj
         INTEGER kstar1,kstar2
-        REAL*8 yeardy
-        PARAMETER(yeardy=365.24d0)
+        REAL*8 yeardy,rsunau
+        PARAMETER(yeardy=365.24d0,rsunau=0.0047d0)
 
         jp = MIN(900,jp + 1)
         bpp(jp,1) = tphys
@@ -31,7 +32,9 @@
 * system was disrupted and tb=-1 and should stay that way
             bpp(jp,7) = tb
         else
-            bpp(jp,7) = tb*yeardy
+            sep_cubed = (sep*rsunau)*(sep*rsunau)*(sep*rsunau)
+            tb_write = sqrt(sep_cubed/(mass1+mass2))
+            bpp(jp,7) = tb_write*yeardy
         endif
         bpp(jp,8) = ecc
         bpp(jp,9) = rrl1
@@ -106,15 +109,15 @@
 *
         REAL*8 tphys,mass0_1,mass_1,lumin_1,rad_1,teff_1
         REAL*8 massc_1,radc_1,menv_1,renv_1,epoch_1
-        REAL*8 ospin_1,deltam_1,RROL_1
+        REAL*8 ospin_1,deltam_1,RROL_1,porb_write,sep_cubed
         REAL*8 mass0_2,mass_2,lumin_2,rad_2,teff_2,massc_2
         REAL*8 radc_2,menv_2,renv_2,epoch_2,ospin_2,deltam_2
         REAL*8 RROL_2,porb,sep,ecc,B_0_1,B_0_2
         REAL*8 SNkick_1,SNkick_2,Vsys_final,SNtheta_final
         INTEGER kstar_1,kstar_2,SN_1,SN_2,bin_state,merger_type
         INTEGER ip
-        REAL*8 yeardy
-        PARAMETER(yeardy=365.24d0)
+        REAL*8 yeardy,rsunau
+        PARAMETER(yeardy=365.24d0,rsunau=0.0047d0)
 
         ip = ip + 1
         bcm(ip,1) = tphys
@@ -150,7 +153,9 @@
 * system was disrupted and porb=-1 and should stay that way
             bcm(ip,30) = porb
         else
-            bcm(ip,30) = porb*yeardy
+            sep_cubed = (sep*rsunau)*(sep*rsunau)*(sep*rsunau)
+            porb_write = sqrt(sep_cubed/(mass_1+mass_2))
+            bcm(ip,30) = porb_write*yeardy
         endif
         bcm(ip,31) = sep
         bcm(ip,32) = ecc

--- a/cosmic/src/bpp_array.f
+++ b/cosmic/src/bpp_array.f
@@ -19,7 +19,7 @@
         INTEGER jp,jj
         INTEGER kstar1,kstar2
         REAL*8 yeardy,rsunau
-        PARAMETER(yeardy=365.24d0,rsunau=0.0047d0)
+        PARAMETER(yeardy=365.24d0,rsunau=0.00465d0)
 
         jp = MIN(900,jp + 1)
         bpp(jp,1) = tphys
@@ -117,7 +117,7 @@
         INTEGER kstar_1,kstar_2,SN_1,SN_2,bin_state,merger_type
         INTEGER ip
         REAL*8 yeardy,rsunau
-        PARAMETER(yeardy=365.24d0,rsunau=0.0047d0)
+        PARAMETER(yeardy=365.24d0,rsunau=0.00465d0)
 
         ip = ip + 1
         bcm(ip,1) = tphys

--- a/cosmic/tests/test_utils.py
+++ b/cosmic/tests/test_utils.py
@@ -73,7 +73,7 @@ class TestUtils(unittest2.TestCase):
         self.assertRaises(ValueError, utils.conv_select, BCM_TEST, BPP_TEST, [11], [11], wrong_dict, {})
 
         conv = utils.conv_select(BCM_TEST, BPP_TEST, [11], [11], conv_dict_formation['convergence_filter'], {})
-        self.assertTrue(np.all(conv.evol_type.isin([2,7])))
+        self.assertTrue(np.all(conv.evol_type.isin([2,4])))
         self.assertTrue(np.all(conv.sep >= 0))
 
         conv = utils.conv_select(BCM_TEST, BPP_TEST, [13,14], range(0,15), conv_dict_1_SN['convergence_filter'], {})

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -168,7 +168,8 @@ def conv_select(bcm_save, bpp_save, final_kstar_1, final_kstar_2, method, conv_l
         # final kstars
         conv_save = bpp_save.loc[(bpp_save.kstar_1.isin(final_kstar_1)) &\
                                  (bpp_save.kstar_2.isin(final_kstar_2)) &\
-                                 (bpp_save.sep > 0)]
+                                 (bpp_save.sep > 0) &\
+                                 (bpp_save.evol_type.isin([2.0,4.0]))]
 
         # select the formation parameters
         conv_save = conv_save.groupby('bin_num').first().reset_index()


### PR DESCRIPTION
The simplest way to make sure that porb is written properly is to compute it just before you write. Tests have been updated since the wrong porb was written.