### PR TITLE
Plot scripts

### DIFF
--- a/cosmic/plotting.py
+++ b/cosmic/plotting.py
@@ -76,10 +76,15 @@ def evolve_binary(initC, t_min=None, t_max=None, BSEDict={}):
     pd.options.mode.chained_assignment = None
 
     # Get highest BSE temporal resolution
-    if t_max < 100:
-        initC['dtp'] = 0.01
-    if t_max > 100:
-        initC['dtp'] = t_max / 10000
+    initC['dtp'] = 0.01
+
+    # To deal with the limited size of the bcm array, we need to reduce
+    # the time resolution if we are evolving a binary for more than 100 Myr
+    if not t_max is None:
+        if not t_min is None:
+            if t_max-t_min > 100: initC['dtp'] = (t_max-t_min) / 10000
+        else:
+            if t_max > 100: initC['dtp'] = t_max / 10000
 
     # Set maximum time for evolution
     if not t_max is None: initC['tphysf'] = t_max

--- a/cosmic/plotting.py
+++ b/cosmic/plotting.py
@@ -73,10 +73,13 @@ def evolve_binary(initC, t_min=None, t_max=None, BSEDict={}):
 
     # Disable chained warning for now which throws
     # a warning for setting dtp and tphysf
-    pd.options.mode.chained_assignment = None 
+    pd.options.mode.chained_assignment = None
 
     # Get highest BSE temporal resolution
-    initC['dtp'] = 0.01
+    if t_max < 100:
+        initC['dtp'] = 0.01
+    if t_max > 100:
+        initC['dtp'] = t_max / 10000
 
     # Set maximum time for evolution
     if not t_max is None: initC['tphysf'] = t_max


### PR DESCRIPTION
Because the plotting scripts set dtp to 0.01, if you wanted to plot the evolution of binaries for longer than 200 Myr, it broke. The update allows for one to plot for longer times, with a resolution of 10,000 steps.