### PR TITLE
Qcflag wrapup

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1986,6 +1986,39 @@ component.
                 qc = 0.625d0
              endif
          endif
+      elseif((qcflag.eq.4)then
+*
+* Use the StarTrack prescriptions taken from Belczynski+2008
+* section 5.1
+* If q1 = m_donor/m_acc > qc then common envelope
+*
+* Note: this does not do the WD mass ratios exactly the same.
+* We do the standard 0.628 mass ratio from BSE since we don't
+* compute the mass transfer rates the same
+         if(kstar(j1).eq.0)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.1)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.2)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.3)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.4)then
+            qc = 3.d0
+         elseif(kstar(j1).eq.5)then
+            qc = 3.d0 
+         elseif(kstar(j1).eq.6)then
+            qc = 3.d0 
+         elseif(kstar(j1).eq.7)then
+            qc = 1.7d0
+         elseif(kstar(j1).eq.8)then
+            qc = 3.5
+         elseif(kstar(j1).eq.9)then
+            qc = 3.5
+         elseif(kstar(j1).ge.10)then
+            qc = 0.628
+         endif
+
       endif
 *
 * Allow for manually overriding qcrit values with fixed

--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -1986,7 +1986,7 @@ component.
                 qc = 0.625d0
              endif
          endif
-      elseif((qcflag.eq.4)then
+      elseif(qcflag.eq.4)then
 *
 * Use the StarTrack prescriptions taken from Belczynski+2008
 * section 5.1
@@ -2018,7 +2018,6 @@ component.
          elseif(kstar(j1).ge.10)then
             qc = 0.628
          endif
-
       endif
 *
 * Allow for manually overriding qcrit values with fixed

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -802,8 +802,6 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
             raise ValueError("'{0:s}' values must be greater than or equal to zero (you set them to '[{1:d}]')".format(flag, *BSEDict[flag]))
         if len(BSEDict[flag]) != 16:
             raise ValueError("'{0:s}' must be supplied 16 values (you supplied '{1:d}')".format(flag, len(BSEDict[flag])))
-        if (any( x != 0.0 for x in BSEDict[flag])) and (BSEDict['qcflag'] != 4):
-            raise ValueError("If '{0:s}' is used, qcflag must be set to 4".format(flag))
 
     flag='sigma'
     if flag in BSEDict.keys():

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -471,7 +471,8 @@ sampling
                             ``3`` : same as 2 but with `Hjellming & Webbink 1987 <https://ui.adsabs.harvard.edu/abs/1987ApJ...318..794H/abstract>`_
                             for GB/AGB stars
 
-                         **qcflag = 2**
+                            ``4`` : follows `Section 5.1 of Belcyznski+2008 <https://ui.adsabs.harvard.edu/abs/2008ApJS..174..223B/abstract>`_ except for WD donors which follow BSE
+                         **qcflag = 1**
 
 ``qcrit_array``          Array with length: 16 for user-input values for the 
                          critical mass ratios that govern the onset of unstable

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -187,8 +187,9 @@ cehestarflag=0
 ; 1: BSE but with Hjellming & Webbink, 1987, ApJ, 318, 794 GB/AGB stars
 ; 2: following binary_c from Claeys+2014 Table 2
 ; 3: following binary_c from Claeys+2014 Table 2 but with Hjellming & Webbink, 1987, ApJ, 318, 794 GB/AGB stars
-; default=2
-qcflag=2
+; 4: following StarTrack from Belczynski+2008 Section 5.1. WD donors follow standard BSE
+; default=1
+qcflag=1
 
 ; qcrit_array is a 16-length array for user-input values for the critical mass ratios that govern the onset of unstable mass transfer and a common envelope
 ; each item is set individually for its associated kstar, and a value of 0.0 will apply prescription of the qcflag for that kstar


### PR DESCRIPTION
This is pretty simple. I added the prescriptions detail in Section 5.1 of the StarTrack paper: https://ui.adsabs.harvard.edu/abs/2008ApJS..174..223B/abstract 

This is now qcflag = 4. For WDs, we use the same qcrit as BSE since StarTrack does some more fancy WD stuff than we do right now.

I also took out the overly harsh error check that didn't allow you to specify a single qcrit array change.

Params.ini and docs are updated.