### PR TITLE
Issue 351

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -2135,11 +2135,12 @@ component.
             kstar(j2) = 15
          endif
          goto 135
-      elseif(((ABS(ABS(2*kstar(j1)-11)-3).eq.2.or.kstar(j1).eq.9)
-     &        .and.(q(j1).gt.qc.or.radx(j1).le.radc(j1))).or.
+
+      elseif((kstar(j1).eq.3.or.kstar(j1).eq.5.or.kstar(j1).eq.6.or.
+     &        kstar(j1).eq.8.or.kstar(j1).eq.9)
+     &        .and.(q(j1).gt.qc.or.radx(j1).le.radc(j1)).or.
      &        (kstar(j1).eq.2.and.q(j1).gt.qc).or.
      &        (kstar(j1).eq.4.and.q(j1).gt.qc))then
-
 *
 * Common-envelope evolution.
 *

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -387,6 +387,16 @@ sampling
 
     COMMON ENVELOPE FLAGS
 
+**Note:** there are cases where a common envelope is forced regardless of the 
+critical mass ratio for unstable mass transfer. In the following cases, a 
+common envelope occurs regardless of the choices below:
+
+**contact** : the stellar radii go into contact (common for similar ZAMS systems)
+
+**periapse contact** : the periapse distance is smaller than either of the stellar radii (common for highly eccentric systems)
+
+**core Roche overflow** : either of the stellar radii overflow their component's Roche radius (in this case, mass transfer from the convective core is always dynamically unstable)
+
 =======================  =====================================================
 ``alpha1``               Common-envelope efficiency parameter which scales the 
                          efficiency of transferring orbital energy to the 
@@ -479,7 +489,11 @@ sampling
                          mass transfer and a common envelope. Each item is set 
                          individually for its associated kstar, and a value of 
                          0.0 will apply prescription of the qcflag for that kstar.
-                         
+                         **Note:** there are cases where a common envelope is forced 
+                         regardless of the critical mass ratio for unstable mass
+                         transfer; in the following cases, a common envelope occurs
+                         regardless of the qcrit or qcflag                          
+
                          **qcrit_array = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]**
 =======================  =====================================================
 


### PR DESCRIPTION
This PR updates:
(1) the kstar conditional for unstable mass transfer since it is suuper hard to understand on the fly
(2) the documentation for cases where a common envelope is forced regardless of mass transfer stability criteria

Thanks to Mathieu Renzo for bring this up!