### PR TITLE
Write end of RLO to bpp after CE caused by contact

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -3591,12 +3591,33 @@ component.
             endif
             goto 135
          endif
+*
+* Need to confirm that RLO is over
+*
+
+         evolve_type = 4.0
+         rrl1 = rad(1)/rol(1)
+         rrl2 = rad(2)/rol(2)
+         CALL writebpp(jp,tphys,evolve_type,
+     &                 mass(1),mass(2),kstar(1),kstar(2),sep,
+     &                 tb,ecc,rrl1,rrl2,bkick,
+     &                 aj(1),aj(2),tms(1),tms(2),
+     &                 massc(1),massc(2),rad(1),rad(2),
+     &                 mass0(1),mass0(2),lumin(1),lumin(2),
+     &                 radc(1),radc(2),menv(1),menv(2),renv(1),
+     &                 renv(2),ospin(1),ospin(2),B_0(1),B_0(2),
+     &                 bacc(1),bacc(2),tacc(1),tacc(2),epoch(1),
+     &                 epoch(2),bhspin(1),bhspin(2))
+         DO jj = 13,20
+            bkick(jj) = 0.0
+         ENDDO
          dtm = 0.d0
 *
 * Reset orbital parameters as separation may have changed.
 *
          tb = (sep/aursun)*SQRT(sep/(aursun*(mass(1)+mass(2))))
          oorb = twopi/tb
+
          goto 4
       endif
 *


### PR DESCRIPTION
This was solved by adding in a write bpp to account for end of RLO forr post CE binaries that enter a CE as a result of contact

Thanks to Zevin for pointing this out in issue #343