### PR TITLE
Sana initial conditions

### DIFF
--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -100,6 +100,10 @@ def parse_commandline():
                         help="number of processors", type=int, default=1)
     parser.add_argument("--binary_state", nargs='+', type=int)
     parser.add_argument("--sampling_method")
+    parser.add_argument("--primary_model", help="Chooses the initial primary mass function from: salpeter55, kroupa93, kroupa01", type=str)
+    parser.add_argument("--binfrac_model", help="Chooses the binary fraction model from: a float between [0,1] and vanHaaften", type=float)
+    parser.add_argument("--ecc_model", help="Chooses the initial eccentricity distribution model from: thermal, uniform, and sana12", type=str)
+    parser.add_argument("--porb_model", help="Chooses the initial orbital period distribution model from: log_uniform and sana12", type=str)
     parser.add_argument("--SF_start", help="Sets the time in the past when star formation initiates in Myr", type=float)
     parser.add_argument("--SF_duration", help="Sets the duration of constant star formation in Myr", type=float)
     parser.add_argument("--metallicity", type=float)
@@ -169,6 +173,12 @@ if __name__ == '__main__':
                 convergence[argument] = getattr(args, argument)
 
         if argument in sampling.keys():
+            if (sampling[argument] == "independent"):
+               for model in ["primary_model", "porb_model", "ecc_model", "binfrac_model"]:
+                    if (model not in sampling.keys()) and not (getattr(args, model)):
+                        raise ValueError("You have selected the {0} sampler "
+                                         "but not specified a model for {1} "
+                                         "in the inifile or command line".format(sampling[argument], model)) 
             if sampling[argument] != getattr(args, argument):
                 warnings.warn("You are overriding the inifile value of {0}={1} "
                               "with {0}={2} from the commandline".format(argument, sampling[argument], getattr(args, argument)))
@@ -256,12 +266,13 @@ if __name__ == '__main__':
 
         # Select the initial binary sample method from user input
         if sampling['sampling_method'] == 'independent':
-            init_samp_list = InitialBinaryTable.sampler(sampling['sampling_method'],
+            init_samp_list = InitialBinaryTable.sampler(format_ = sampling['sampling_method'],
                                                         final_kstar1 = kstar1_range,
                                                         final_kstar2 = kstar2_range,
-                                                        binfrac_model = 0.5,
-                                                        primary_model = 'kroupa93',
-                                                        ecc_model = 'thermal',
+                                                        binfrac_model = args.binfrac_model,
+                                                        primary_model = args.primary_model,
+                                                        ecc_model = args.ecc_model,
+                                                        porb_model = args.porb_model,
                                                         SF_start = sampling['SF_start'],
                                                         SF_duration = sampling['SF_duration'],
                                                         met = sampling['metallicity'],
@@ -269,7 +280,7 @@ if __name__ == '__main__':
             IBT, mass_singles, mass_binaries, n_singles, n_binaries = init_samp_list
 
         if sampling['sampling_method'] == 'multidim':
-            init_samp_list = InitialBinaryTable.sampler(sampling['sampling_method'],
+            init_samp_list = InitialBinaryTable.sampler(format_ = sampling['sampling_method'],
                                                         final_kstar1 = kstar1_range,
                                                         final_kstar2 = kstar2_range,
                                                         rand_seed = rand_seed,

--- a/bin/cosmic-pop
+++ b/bin/cosmic-pop
@@ -173,7 +173,7 @@ if __name__ == '__main__':
                 convergence[argument] = getattr(args, argument)
 
         if argument in sampling.keys():
-            if (sampling[argument] == "independent"):
+            if (sampling[argument] == "independent") or (getattr(args, argument) == "independent"):
                for model in ["primary_model", "porb_model", "ecc_model", "binfrac_model"]:
                     if (model not in sampling.keys()) and not (getattr(args, model)):
                         raise ValueError("You have selected the {0} sampler "

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -37,7 +37,7 @@ __credits__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
 __all__ = ['get_independent_sampler', 'Sample']
 
 
-def get_independent_sampler(final_kstar1, final_kstar2, primary_model, ecc_model, SF_start, SF_duration, binfrac_model, met, size, **kwargs):
+def get_independent_sampler(final_kstar1, final_kstar2, primary_model, ecc_model, porb_model,  SF_start, SF_duration, binfrac_model, met, size, **kwargs):
     """Generates an initial binary sample according to user specified models
 
     Parameters

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -141,7 +141,7 @@ def get_independent_sampler(final_kstar1, final_kstar2, primary_model, ecc_model
     mass2_binary = np.array(mass2_binary)
     binfrac = np.asarray(binfrac)
     ecc =  initconditions.sample_ecc(ecc_model, size = mass1_binary.size)
-    porb =  initconditions.sample_porb(mass1_binary, mass2_binary, porb_model, size=mass1_binary.size)
+    porb =  initconditions.sample_porb(mass1_binary, mass2_binary, ecc, porb_model, size=mass1_binary.size)
     tphysf, metallicity = initconditions.sample_SFH(SF_start=SF_start, SF_duration=SF_duration, met=met, size = mass1_binary.size)
     metallicity[metallicity < 1e-4] = 1e-4
     metallicity[metallicity > 0.03] = 0.03
@@ -270,7 +270,7 @@ class Sample(object):
             primary_mass
         """
 
-        a_0 = np.random.uniform(0.001, 1, primary_mass.size)
+        a_0 = np.random.uniform(0.01, 1, primary_mass.size)
         secondary_mass = primary_mass*a_0
 
         return secondary_mass
@@ -325,7 +325,7 @@ class Sample(object):
         return primary_mass[binaryIdx], primary_mass[singleIdx], binary_fraction[binaryIdx]
 
 
-    def sample_porb(self, mass1, mass2, model='sana12', size=None):
+    def sample_porb(self, mass1, mass2, ecc, model='sana12', size=None):
         """Sample the orbital period according to the user-specified model
         
         Parameters
@@ -334,6 +334,8 @@ class Sample(object):
             primary masses
         mass2 : array
             secondary masses
+        ecc : array
+            eccentricity
         model : string
             selects which model to sample orbital periods, choices include:
             log_uniform : semi-major axis flat in log space from RROL < 0.5 up
@@ -407,7 +409,7 @@ class Sample(object):
             from cosmic.utils import rndm
             porb = 10**(np.random.uniform(0.15, 5.5, size))
             ind_massive, = np.where(mass1 > 15)
-            porb[ind_massive] = 10**rndm(a=0.15, b=5.5, g=-0.55, size=len(ind_massive)])
+            porb[ind_massive] = 10**rndm(a=0.15, b=5.5, g=-0.55, size=len(ind_massive))
         else:
             raise ValueError('You have supplied a non-supported model; Please choose either log_flat or Sana')
         return porb
@@ -446,7 +448,8 @@ class Sample(object):
 
         elif ecc_model=='sana12':
             from cosmic.utils import rndm
-            ecc = rndm(a=0.0, b=0.9, g=-0.42, size=size) 
+            ecc = rndm(a=0.001, b=0.9, g=-0.42, size=size) 
+            return ecc
         else:
             raise Error('You have specified an unsupported model. Please choose from thermal, uniform, or Sana')
 

--- a/cosmic/sample/sampler/independent.py
+++ b/cosmic/sample/sampler/independent.py
@@ -52,7 +52,10 @@ def get_independent_sampler(final_kstar1, final_kstar2, primary_model, ecc_model
         Model to sample primary mass; choices include: kroupa93, kroupa01, salpeter55
 
     ecc_model : `str`
-        Model to sample eccentricity; choices include: thermal, uniform
+        Model to sample eccentricity; choices include: thermal, uniform, sana12
+
+    porb_model : `str`
+        Model to sample orbital period; choices include: log_uniform, sana12
 
     SF_start : `float`
             Time in the past when star formation initiates in Myr
@@ -138,7 +141,7 @@ def get_independent_sampler(final_kstar1, final_kstar2, primary_model, ecc_model
     mass2_binary = np.array(mass2_binary)
     binfrac = np.asarray(binfrac)
     ecc =  initconditions.sample_ecc(ecc_model, size = mass1_binary.size)
-    porb =  initconditions.sample_porb(mass1_binary, mass2_binary, ecc, size=mass1_binary.size)
+    porb =  initconditions.sample_porb(mass1_binary, mass2_binary, porb_model, size=mass1_binary.size)
     tphysf, metallicity = initconditions.sample_SFH(SF_start=SF_start, SF_duration=SF_duration, met=met, size = mass1_binary.size)
     metallicity[metallicity < 1e-4] = 1e-4
     metallicity[metallicity > 0.03] = 0.03
@@ -156,7 +159,7 @@ register_sampler('independent', InitialBinaryTable, get_independent_sampler,
 class Sample(object):
 
     # sample primary masses
-    def sample_primary(self, primary_model='kroupa93', size=None):
+    def sample_primary(self, primary_model='kroupa01', size=None):
         """Sample the primary mass (always the most massive star) from a user-selected model
 
         kroupa93 follows Kroupa (1993), normalization comes from
@@ -187,7 +190,7 @@ class Sample(object):
             `Hurley 2002 <https://arxiv.org/abs/astro-ph/0009005>`_
             valid for masses between 0.1 and 100 Msun
 
-            Default kroupa93
+            Default kroupa01
         size : int, optional
             number of initial primary masses to sample
             NOTE: this is set in cosmic-pop call as Nstep
@@ -322,77 +325,92 @@ class Sample(object):
         return primary_mass[binaryIdx], primary_mass[singleIdx], binary_fraction[binaryIdx]
 
 
-    def sample_porb(self, mass1, mass2, ecc, size=None):
-        """Sample the semi-major axis flat in log space from RROL < 0.5 up
-        to 1e5 Rsun according to
-        `Abt (1983) <http://adsabs.harvard.edu/abs/1983ARA%26A..21..343A>`_
-        and consistent with Dominik+2012,2013
-        and then converted to orbital period in days using Kepler III
-
+    def sample_porb(self, mass1, mass2, model='sana12', size=None):
+        """Sample the orbital period according to the user-specified model
+        
         Parameters
         ----------
         mass1 : array
             primary masses
         mass2 : array
             secondary masses
-        ecc : array
-            eccentricities
+        model : string
+            selects which model to sample orbital periods, choices include:
+            log_uniform : semi-major axis flat in log space from RROL < 0.5 up
+                       to 1e5 Rsun according to
+                       `Abt (1983) <http://adsabs.harvard.edu/abs/1983ARA%26A..21..343A>`_
+                        and consistent with Dominik+2012,2013
+                        and then converted to orbital period in days using Kepler III
+            sana12 : power law orbital period for m1 > 15Msun binaries from 
+                        `Sana+2012 <https://ui.adsabs.harvard.edu/abs/2012Sci...337..444S/abstract>_` 
+                        following the implementation of 
+                        `Renzo+2019 <https://ui.adsabs.harvard.edu/abs/2019A%26A...624A..66R/abstract>_` and flat in log otherwise
+
 
         Returns
         -------
-        porb_sec/sec_in_day : array
+        porb : array
             orbital period with array size equalling array size
-            of mass1 and mass2
+            of mass1 and mass2 in units of days
         """
-        q = mass2/mass1
-        RL_fac = (0.49*q**(2./3.)) / (0.6*q**(2./3.) + np.log(1+q**1./3.))
+        if model == 'log_uniform':     
+            q = mass2/mass1
+            RL_fac = (0.49*q**(2./3.)) / (0.6*q**(2./3.) + np.log(1+q**1./3.))
 
-        q2 = mass1/mass2
-        RL_fac2 = (0.49*q2**(2./3.)) / (0.6*q2**(2./3.) + np.log(1+q2**1./3.))
-        try:
-            ind_lo, = np.where(mass1 < 1.66)
-            ind_hi, = np.where(mass1 >= 1.66)
+            q2 = mass1/mass2
+            RL_fac2 = (0.49*q2**(2./3.)) / (0.6*q2**(2./3.) + np.log(1+q2**1./3.))
+            try:
+                ind_lo, = np.where(mass1 < 1.66)
+                ind_hi, = np.where(mass1 >= 1.66)
 
-            rad1 = np.zeros(len(mass1))
-            rad1[ind_lo] = 1.06*mass1[ind_lo]**0.945
-            rad1[ind_hi] = 1.33*mass1[ind_hi]**0.555
-        except:
-            if mass1 < 1.66:
-                rad1 = 1.06*mass1**0.945
-            else:
-                rad1 = 1.33*mass1**0.555
+                rad1 = np.zeros(len(mass1))
+                rad1[ind_lo] = 1.06*mass1[ind_lo]**0.945
+                rad1[ind_hi] = 1.33*mass1[ind_hi]**0.555
+            except:
+                if mass1 < 1.66:
+                    rad1 = 1.06*mass1**0.945
+                else:
+                    rad1 = 1.33*mass1**0.555
 
-        try:
-            ind_lo, = np.where(mass2 < 1.66)
-            ind_hi, = np.where(mass2 >= 1.66)
+            try:
+                ind_lo, = np.where(mass2 < 1.66)
+                ind_hi, = np.where(mass2 >= 1.66)
 
-            rad2 = np.zeros(len(mass2))
-            rad2[ind_lo] = 1.06*mass2[ind_lo]**0.945
-            rad2[ind_hi] = 1.33*mass2[ind_hi]**0.555
-        except:
-            if mass2 < 1.66:
-                rad2 = 1.06*mass1**0.945
-            else:
-                rad2 = 1.33*mass1**0.555
+                rad2 = np.zeros(len(mass2))
+                rad2[ind_lo] = 1.06*mass2[ind_lo]**0.945
+                rad2[ind_hi] = 1.33*mass2[ind_hi]**0.555
+            except:
+                if mass2 < 1.66:
+                    rad2 = 1.06*mass1**0.945
+                else:
+                    rad2 = 1.33*mass1**0.555
 
-        # include the factor for the eccentricity
-        RL_max = 2*rad1/RL_fac
-        ind_switch, = np.where(RL_max < 2*rad2/RL_fac2)
-        if len(ind_switch) >= 1:
-            RL_max[ind_switch] = 2*rad2/RL_fac2[ind_switch]
-        a_min = RL_max*(1+ecc)
-        a_0 = np.random.uniform(np.log(a_min), np.log(1e5), size)
+            # include the factor for the eccentricity
+            RL_max = 2*rad1/RL_fac
+            ind_switch, = np.where(RL_max < 2*rad2/RL_fac2)
+            if len(ind_switch) >= 1:
+                RL_max[ind_switch] = 2*rad2/RL_fac2[ind_switch]
+            a_min = RL_max*(1+ecc)
+            a_0 = np.random.uniform(np.log(a_min), np.log(1e5), size)
 
-        # convert out of log space
-        a_0 = np.exp(a_0)
-        # convert to au
-        rsun_au = 0.00465047
-        a_0 = a_0*rsun_au
+            # convert out of log space
+            a_0 = np.exp(a_0)
+            # convert to au
+            rsun_au = 0.00465047
+            a_0 = a_0*rsun_au
 
-        # convert to orbital period in years
-        yr_day = 365.24
-        porb_yr = ((a_0**3.0)/(mass1+mass2))**0.5
-        return porb_yr*yr_day
+            # convert to orbital period in years
+            yr_day = 365.24
+            porb_yr = ((a_0**3.0)/(mass1+mass2))**0.5
+            porb = porb_yr*yr_day
+        elif model == 'sana12':
+            from cosmic.utils import rndm
+            porb = 10**(np.random.uniform(0.15, 5.5, size))
+            ind_massive, = np.where(mass1 > 15)
+            porb[ind_massive] = 10**rndm(a=0.15, b=5.5, g=-0.55, size=len(ind_massive)])
+        else:
+            raise ValueError('You have supplied a non-supported model; Please choose either log_flat or Sana')
+        return porb
 
 
     def sample_ecc(self, ecc_model='thermal', size=None):
@@ -404,7 +422,8 @@ class Sample(object):
             'thermal' samples from a  thermal eccentricity distribution following
             `Heggie (1975) <http://adsabs.harvard.edu/abs/1975MNRAS.173..729H>`_
             'uniform' samples from a uniform eccentricity distribution
-            DEFAULT = 'thermal'
+            'Sana' samples from the eccentricity distribution from `Sana+2012 <https://ui.adsabs.harvard.edu/abs/2012Sci...337..444S/abstract>_`
+            DEFAULT = 'Sana'
 
         size : int, optional
             number of eccentricities to sample
@@ -425,8 +444,11 @@ class Sample(object):
             ecc = np.random.uniform(0.0, 1.0, size)
             return ecc
 
+        elif ecc_model=='sana12':
+            from cosmic.utils import rndm
+            ecc = rndm(a=0.0, b=0.9, g=-0.42, size=size) 
         else:
-            raise Error('You have specified an unsupported model. Please choose from thermal or uniform')
+            raise Error('You have specified an unsupported model. Please choose from thermal, uniform, or Sana')
 
 
     def sample_SFH(self, SF_start=13700.0, SF_duration=0.0, met=0.02, size=None):

--- a/cosmic/tests/test_sample.py
+++ b/cosmic/tests/test_sample.py
@@ -17,15 +17,17 @@ TEST_DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 TOTAL_SAMPLED_MASS_KROUPA93 = 39.253472063203404
 TOTAL_SAMPLED_MASS_KROUPA01 = 28.708454104214034
 TOTAL_SAMPLED_MASS_SALPETER55 = 22.575833208553195
-TOTAL_SECONDARY_MASS = 16.15470927770034
+TOTAL_SECONDARY_MASS = 16.41457676168502
 N_BINARY_SELECT = 85
 VANHAAFTEN_BINFRAC_MAX = 0.9989087986493874
 VANHAAFTEN_BINFRAC_MIN = 0.6192803136799157
 MULTIDIM_BINFRAC_MAX = 0.6146916774140262
 MULTIDIM_BINFRAC_MIN = 0.13786300908773025
 PORB = 670.88711347
+PORB_SANA12 = 303.789477175485
 THERMAL_ECC_SUM = 5.7488819291685695
 UNIFORM_ECC_SUM = 3.58801017672414
+SANA12_ECC_SUM = 0.03346470981696298
 CONST_SFR_SUM = 460028.2453521937
 BURST_SFR_SUM = 946002.8245352195
 KSTAR_SOLAR = 1.0
@@ -93,11 +95,21 @@ class TestSample(unittest2.TestCase):
         ecc = SAMPLECLASS.sample_ecc(ecc_model='uniform', size=10)
         self.assertEqual(ecc.sum(), UNIFORM_ECC_SUM)
 
+        np.random.seed(2)
+        # Check that the sample_ecc function samples ecc properly
+        ecc = SAMPLECLASS.sample_ecc(ecc_model='sana12', size=10)
+        self.assertEqual(ecc.sum(), SANA12_ECC_SUM)
+
     def test_sample_porb_abt(self):
         np.random.seed(2)
         # Check that the sample_porb function samples porb properly
-        porb = SAMPLECLASS.sample_porb(1.0, 1.0, 0.5, size=1)
+        porb = SAMPLECLASS.sample_porb(1.0, 1.0, 0.5, 'log_uniform', size=1)
         self.assertAlmostEqual(porb[0], PORB)
+
+    def test_sample_porb_sana12(self):
+        np.random.seed(2)
+        porb = SAMPLECLASS.sample_porb(1.0, 1.0, 0.5, 'sana12', size=1)
+        self.assertAlmostEqual(porb[0], PORB_SANA12)
 
     def test_sample_SFH(self):
         np.random.seed(2)

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -818,11 +818,11 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
     flag='aic'
     if flag in BSEDict.keys():
         if BSEDict[flag] not in [0,1]:
-            raise valueerror("'{0:s}' needs to be set to either 0 or 1 (you set it to '{1:d}')".format(flag, BSEDict[flag]))
+            raise ValueError("'{0:s}' needs to be set to either 0 or 1 (you set it to '{1:d}')".format(flag, BSEDict[flag]))
     flag='ussn'
     if flag in BSEDict.keys():
         if BSEDict[flag] not in [0,1]:
-            raise valueerror("'{0:s}' needs to be set to either 0 or 1 (you set it to '{1:d}')".format(flag, BSEDict[flag]))
+            raise ValueError("'{0:s}' needs to be set to either 0 or 1 (you set it to '{1:d}')".format(flag, BSEDict[flag]))
     flag='pisn'
     if flag in BSEDict.keys():
         if not ((BSEDict[flag] >= 0) or (BSEDict[flag] == -1) or (BSEDict[flag] == -2) or (BSEDict[flag] == -3)):

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -22,7 +22,7 @@ sampling_method = multidim
 ;porb_model = sana12
 
 ; Selects the eccentricity model: thermal, uniform, sana12
-;ecc_model = thermal
+;ecc_model = sana12
 
 ; Selects the binary fraction
 ;binfrac_model = 0.5

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -11,6 +11,22 @@ binary_state = [0,1]
 ; initial conditions follow Moe & Di Stefano (2017) (multidim)
 sampling_method = multidim
 
+; If the sampling_method is independent, there are different
+; models available for the inital eccentricity, orbital period,
+; primary mass and binary fraction
+
+; Selects the primary mass model: salpeter55, kroupa93, kroupa01
+;primary_model = kroupa01
+
+; Selects the orbital period model: sana12, log_uniform
+;porb_model = sana12
+
+; Selects the eccentricity model: thermal, uniform, sana12
+;ecc_model = thermal
+
+; Selects the binary fraction
+;binfrac_model = 0.5
+
 ; Sets the time in the past when star formation initiates in Myr
 SF_start = 13700.0
 


### PR DESCRIPTION
This PR incorporates new initial condition models for the independent sampler by request of @michaelzevin (but really everyone).

Some notes: 
- we adopt the methods of Renzo+2019 which assumes flat in log for m1 < 15 Msun and the power law for m1 >= 15 Msun. This is because the sana+2012 paper focused on *massive* stars
- the Sana+2012 observations for eccentricities are also for massive stars, which might circularize quite a bit from pre-ZAMS interactions since they are close.... thus the eccentricity is pretty severely peaked toward 0.0; for this reason, I recommend that we don't use sana12 as an ecc default for all types of stars.

tests should all be updated!