### PR TITLE
quick fix to point-mass CMC sampler

### DIFF
--- a/cosmic/sample/sampler/cmc.py
+++ b/cosmic/sample/sampler/cmc.py
@@ -229,7 +229,7 @@ def get_cmc_point_mass_sampler(
     binaries_table = InitialCMCTable.InitialCMCBinaries(1,1,0,0,0,1,0,0,0,0,0)
 
     singles_table.metallicity = 0.02
-    singles_table.mass_of_cluster = np.sum(singles_table["m"])
+    singles_table.mass_of_cluster = np.sum(singles_table["m"])*size
     binaries_table.metallicity = 0.02
 
     return singles_table, binaries_table


### PR DESCRIPTION
Slight adjustment to the total mass of cluster hdf5's generated for CMC.  Doesn't change any underlying physics, just agrees better with CMC's code  units for mass