### PR TITLE
quick fix for CMC

### DIFF
--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -1560,9 +1560,11 @@ def parse_inifile(inifile):
 
     # ---- Read needed variables from the inifile
     dictionary = {}
+    generating_cmc_ics = False
     for section in cp.sections():
         # for cosmic we skip any CMC stuff
         if section == "cmc":
+            generating_cmc_ics = True
             continue
         dictionary[section] = {}
         for option in cp.options(section):
@@ -1573,10 +1575,16 @@ def parse_inifile(inifile):
                 dictionary[section][option] = json.loads(opt)
 
     BSEDict = dictionary["bse"]
-    seed_int = int(dictionary["rand_seed"]["seed"])
-    filters = dictionary["filters"]
-    convergence = dictionary["convergence"]
-    sampling = dictionary["sampling"]
+    if not generating_cmc_ics:
+        seed_int = int(dictionary["rand_seed"]["seed"])
+        filters = dictionary["filters"]
+        convergence = dictionary["convergence"]
+        sampling = dictionary["sampling"]
+    else:
+        seed_int = 0
+        filters = 0
+        convergence = 0
+        sampling = 0
 
     return BSEDict, seed_int, filters, convergence, sampling
 

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -1562,14 +1562,18 @@ def parse_inifile(inifile):
     dictionary = {}
     for section in cp.sections():
         # for cosmic we skip any CMC stuff
-        # As long as the CMC section is first, any of the below options will be
-        # overwritten by the later sections
+        # if "cmc" is a section in the ini file, then we can optionally skip the 
+        # COSMIC population sections (or not, if they exist)
         if section == "cmc":
-            dictionary["rand_seed"] = {}
-            dictionary["rand_seed"]["seed"] = 0
-            dictionary["filters"] = 0
-            dictionary["convergence"] = 0
-            dictionary["sampling"] = 0
+            if "rand_seed" not in dictionary.keys():
+                dictionary["rand_seed"] = {}
+                dictionary["rand_seed"]["seed"] = 0
+            if "filters" not in dictionary.keys():
+                dictionary["filters"] = 0
+            if "convergence" not in dictionary.keys():
+                dictionary["convergence"] = 0
+            if "sampling" not in dictionary.keys():
+                dictionary["sampling"] = 0
             continue
         dictionary[section] = {}
         for option in cp.options(section):

--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -1560,11 +1560,16 @@ def parse_inifile(inifile):
 
     # ---- Read needed variables from the inifile
     dictionary = {}
-    generating_cmc_ics = False
     for section in cp.sections():
         # for cosmic we skip any CMC stuff
+        # As long as the CMC section is first, any of the below options will be
+        # overwritten by the later sections
         if section == "cmc":
-            generating_cmc_ics = True
+            dictionary["rand_seed"] = {}
+            dictionary["rand_seed"]["seed"] = 0
+            dictionary["filters"] = 0
+            dictionary["convergence"] = 0
+            dictionary["sampling"] = 0
             continue
         dictionary[section] = {}
         for option in cp.options(section):
@@ -1575,16 +1580,10 @@ def parse_inifile(inifile):
                 dictionary[section][option] = json.loads(opt)
 
     BSEDict = dictionary["bse"]
-    if not generating_cmc_ics:
-        seed_int = int(dictionary["rand_seed"]["seed"])
-        filters = dictionary["filters"]
-        convergence = dictionary["convergence"]
-        sampling = dictionary["sampling"]
-    else:
-        seed_int = 0
-        filters = 0
-        convergence = 0
-        sampling = 0
+    seed_int = int(dictionary["rand_seed"]["seed"])
+    filters = dictionary["filters"]
+    convergence = dictionary["convergence"]
+    sampling = dictionary["sampling"]
 
     return BSEDict, seed_int, filters, convergence, sampling
 


### PR DESCRIPTION
For the independent sampler, removes the need for a bunch of the COSMIC specific dictionary entries in the ini files (e.g. "convergence", "sampling", etc).