### PR TITLE
fixing NaN that appear for second omega angle

### DIFF
--- a/cosmic/src/kick.f
+++ b/cosmic/src/kick.f
@@ -417,7 +417,12 @@
      &               - comega*comega1*smu*smu1
 
         kick_info(sn,15) = ACOS(z_tilt)*180/pi
-        kick_info(sn,16) = ATAN(y_tilt/x_tilt)*180/pi
+* If both kicks were 0 then x_tilt for SN2 will be 0 since smu=0
+        if(x_tilt.eq.0)then
+          kick_info(sn,16) = 0
+        else
+          kick_info(sn,16) = ATAN(y_tilt/x_tilt)*180/pi
+        endif
         kick_info(sn,6) = mm*180/pi
         if(using_cmc.eq.0)then
             natal_kick_array(snstar,4) = mm*180/pi


### PR DESCRIPTION
This small change fixes a (not-so) edge case. When both SNe have kicks of 0.0 (which is common for BBHs), the x_tilt that is calculated for the second SN is 0 since the angle between the angular momentum vectors is 0. When omega2 is then calculated, we get a divide by zero in a trigonometric function that leads to the NaN value in kick_info. 

I just added a simple if/else to address this edge case (setting omega2 to 0). I checked that [multiple binaries example on the Docs](https://cosmic-popsynth.github.io/COSMIC/examples/index.html#multiple-binaries) and it seems to have fixed things. 