### PR TITLE
ecsn fixes to fallback prescriptions

### DIFF
--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -533,7 +533,8 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Use NS/BH masses given by Belczynski+08. PK.
 *
                      !First calculate the proto-core mass
-                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn)then
+                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn.and.
+     &                    mcbagb.ge.ecsn_mlow)then
                         mcx = 1.38d0
                      elseif(ecsn.eq.0.d0.and.mcbagb.le.2.25d0)then !this should be ecsn, unless ecsn=0
 *                     if(mcbagb.le.2.35d0)then
@@ -579,15 +580,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 *
 *                    We use the updated proto-core mass from Giacobbo & Mapelli 2020
                      mcx = 1.1d0
-                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn)then
-                        mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mcbagb.le.2.25d0)then !this should be ecsn, unless ecsn=0
-                        mcx = 1.38d0
-                     endif
-                     if(mc.le.2.5d0)then
+                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn.and.
+     &                    mcbagb.ge.ecsn_mlow)then
+                        mt = 1.38d0   ! ECSN fixed mass, no fallback
+                     elseif(mc.le.2.5d0)then
                         fallback = 0.2d0 / (mt - mcx) 
                         mt = mcx + 0.2d0
-                        if(ecsn.gt.0.d0.and.mcbagb.le.ecsn)mt=mt-0.2d0
                      elseif(mc.le.6.d0)then
                         fallback = (0.286d0*mc - 0.514d0) / (mt - mcx)
                         mt = mcx + 0.286d0*mc - 0.514d0
@@ -629,10 +627,13 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      elseif(mc.gt.11.d0)then
                         mcx = 1.6d0
                      endif
-                     if(mc.lt.2.5d0)then
+
+                     if(ecsn.gt.0.d0.and.mcbagb.le.ecsn.and.
+     &                    mcbagb.ge.ecsn_mlow)then
+                        mt = 1.38d0   ! ECSN fixed mass, no fallback
+                     elseif(mc.lt.2.5d0)then
                         fallback = 0.2d0 / (mt - mcx) 
                         mt = mcx + 0.2
-                        fallback = 0.d0
                      elseif(mc.lt.3.5d0)then
                         fallback = (0.5d0 * mc - 1.05d0) / (mt - mcx)
                         mt = mcx + 0.5d0 * mc - 1.05d0
@@ -912,7 +913,8 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 * Use NS/BH masses given by Belczynski+08. PK.
 *
                      !First calculate the proto-core mass
-                     if(ecsn.gt.0.d0.and.mc.le.ecsn)then
+                     if(ecsn.gt.0.d0.and.mc.le.ecsn.and.
+     &                    mc.ge.ecsn_mlow)then
                         mcx = 1.38d0
                      elseif(ecsn.eq.0.d0.and.mc.le.2.25d0)then !this should be ecsn, unless ecsn=0
                         mcx = 1.38d0
@@ -955,14 +957,12 @@ C      if(mt0.gt.100.d0) mt = 100.d0
 *
 *                    We use the updated proto-core mass from Giacobbo & Mapelli 2020
                      mcx = 1.1d0
-                     if(ecsn.gt.0.d0.and.mc.le.ecsn)then
-                        mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mc.le.2.25d0)then !this should be ecsn, unless ecsn=0
-                        mcx = 1.38d0
-                     endif
-                     if(mc.le.2.5d0)then
+                     if(ecsn.gt.0.d0.and.mc.le.ecsn.and.
+     &                    mc.ge.ecsn_mlow)then
+                        mt = 1.38d0   ! ECSN fixed mass, no fallback
+                     elseif(mc.le.2.5d0)then
+                        fallback = 0.2d0 / (mt - mcx)
                         mt = mcx + 0.2d0
-                        fallback = 0.d0
                      elseif(mc.le.6.d0)then
                         fallback = (0.286d0*mc - 0.514d0) / (mt - mcx)
                         mt = mcx + 0.286d0*mc - 0.514d0
@@ -1004,9 +1004,13 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      elseif(mc.gt.11.d0)then
                         mcx = 1.6d0
                      endif
-                     if(mc.lt.2.5d0)then
+
+                     if(ecsn.gt.0.d0.and.mc.le.ecsn.and.
+     &                    mc.ge.ecsn_mlow)then
+                        mt = 1.38d0   ! ECSN fixed mass, no fallback
+                     elseif(mc.lt.2.5d0)then
+                        fallback = 0.2d0 / (mt - mcx)
                         mt = mcx + 0.2
-                        fallback = 0.d0
                      elseif(mc.lt.3.5d0)then
                         fallback = (0.5d0 * mc - 1.05d0) / (mt - mcx)
                         mt = mcx + 0.5d0 * mc - 1.05d0

--- a/cosmic/src/hrdiag.f
+++ b/cosmic/src/hrdiag.f
@@ -536,9 +536,6 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      if(ecsn.gt.0.d0.and.mcbagb.le.ecsn.and.
      &                    mcbagb.ge.ecsn_mlow)then
                         mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mcbagb.le.2.25d0)then !this should be ecsn, unless ecsn=0
-*                     if(mcbagb.le.2.35d0)then
-                        mcx = 1.38d0
 *                     elseif(mc.lt.4.29d0)then
                      elseif(mc.lt.4.82d0)then
                         mcx = 1.5d0
@@ -915,8 +912,6 @@ C      if(mt0.gt.100.d0) mt = 100.d0
                      !First calculate the proto-core mass
                      if(ecsn.gt.0.d0.and.mc.le.ecsn.and.
      &                    mc.ge.ecsn_mlow)then
-                        mcx = 1.38d0
-                     elseif(ecsn.eq.0.d0.and.mc.le.2.25d0)then !this should be ecsn, unless ecsn=0
                         mcx = 1.38d0
                      elseif(mc.lt.4.82d0)then
                         mcx = 1.5d0


### PR DESCRIPTION
Addressing #432 

There seemed to be some adjustments to the Fryer fallback models for low core mass stars. I've changed so that it now follows Fryer+2012 directly, and also properly accounts for ECSN (including checking ecsn_mlow, which it wasn't doing before). 