### PR TITLE
flow change to evolv2

### DIFF
--- a/cosmic/src/evolv2.f
+++ b/cosmic/src/evolv2.f
@@ -204,7 +204,7 @@
       REAL*8 zero,ngtv,ngtv2,mt2,rrl1,rrl2,mcx,teff1,teff2
       REAL*8 mass1i,mass2i,tbi,ecci
       LOGICAL coel,com,prec,inttry,change,snova,sgl
-      LOGICAL supedd,novae,disk
+      LOGICAL supedd,novae,disk,inspiral
       LOGICAL iplot,isave
       REAL*8 rl,mlwind,vrotf,corerd,f_fac
       EXTERNAL rl,mlwind,vrotf,corerd
@@ -492,6 +492,7 @@ component.
       snova = .false.
       coel = .false.
       com = .false.
+      inspiral = .false.
       tphys0 = tphys
       ecc1 = ecc
       j1 = 1
@@ -3278,6 +3279,11 @@ component.
 * primary overfills its Roche lobe initially. In this case we simply
 * allow contact to occur.
 *
+* NOTE: there is a possibility that if contact occurs and we're at/past
+* the current tphysf, then the binary will spiral in and we don't catch
+* it.  If that happens, we could return an impossibly small binary which
+* will break energy conservation in CMC.  Flag this here
+         if((jorb-djorb).lt.1.d0) inspiral=.true.
          jorb = MAX(1.d0,jorb - djorb)
          sep = (mass(1) + mass(2))*jorb*jorb/
      &         ((mass(1)*mass(2)*twopi)**2*aursun**3*(1.d0-ecc*ecc))
@@ -3554,7 +3560,7 @@ component.
 *     & mass(2),rad(1),rad(2),ospin(1),ospin(2),b01_bcm,b02_bcm,jspin(1)
       endif
 *
-      if(tphys.ge.tphysf) goto 140
+      if(tphys.ge.tphysf.and..not.inspiral) goto 140
 *
       if(change)then
          change = .false.


### PR DESCRIPTION
Ok, this is a tiny but significant change.  Basically when tphysf is sufficiently large (e.g. in CMC) and the CMC timestep is also sufficiently large (e.g. large cluster virial radius) you can run into a condition where COSMIC merges stellar binaries due to a combination of mass transfer/GW by subtracting angular momentum from the orbit (line 3281 in evolv2.f). 

However, if a binary is brought to 0 separation after that line (or ~1e-10), and the tphys if after the current tphysf, this binary can be returned to CMC having not been destroyed (even though the stars are well past contact), because the check for contact/collisions occurs *after* the goto at line 3557.  These binaries have ~10000x the binding energy of the whole cluster, causing CMC to crash when it checks for energy conservation.

To solve this, I've added a check in line 3281 of evolv2, whereby if the change in orbital angular momentum is greater than the total angular momentum, the goto at line 3557 is skipped and BSE checks for collisions before returning the binary to CMC.  

I've tested that this fixes the issues in CMC (it does) and doesn't change anything in COSMIC (at least for single binaries, it doesn't seem to).  However, I haven't run a full COSMIC population.