### PR TITLE
Extend python/numpy/scipy version support and CI fixes

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -6,12 +6,10 @@ on:
   workflow_dispatch:
 
 env:
-  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
   CIBW_ARCHS_LINUX: "x86_64"
-  CIBW_SKIP: "*-win32 *musllinux*"
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_SKIP: "*-win32 *musllinux* *t-*"
   CIBW_ARCHS_MACOS: "x86_64 arm64"
-  CIBW_BEFORE_BUILD: pip install "numpy >= 2.0, < 2.3" --config-settings=setup-args="-Dallow-noblas=true"
   CIBW_BUILD_VERBOSITY: "1"
   CIBW_BEFORE_ALL_LINUX: yum install -y gcc-gfortran
   CIBW_ENVIRONMENT_LINUX: "FC=gfortran F77=gfortran"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,7 +3,11 @@
 
 name: Unit Test COSMIC
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 jobs:
   build:
@@ -47,20 +51,24 @@ jobs:
       run: |
         # upgrade apt-get and install system dependencies
         sudo apt-get update
-        sudo apt-get install gfortran swig libhdf5-serial-dev meson python3-dev
+        sudo apt-get install -y gfortran swig libhdf5-serial-dev python3-dev
 
         # upgrade pip and install build/lint tooling
-        python -m pip install -U pip setuptools wheel packaging flake8
+        python -m pip install -U pip setuptools wheel packaging flake8 \
+          "meson-python>=0.15" "meson>=1.3" ninja \
+          "numpy>=2.0,<2.3; python_version<'3.14'" \
+          "numpy>=2.3.2,<2.6; python_version>='3.14'"
 
     - name: Install package with highest-compatible dependencies
       if: matrix.dependency-set == 'highest'
       run: |
-        python -m pip install .[test]
+        python -m pip install --no-build-isolation -e .[test]
 
     - name: Install package with lowest direct dependencies
       if: matrix.dependency-set == 'lowest'
       run: |
-        python -m pip install -c ci/constraints-lowest.txt .[test]
+        python -m pip install -c ci/constraints-lowest.txt "numpy>=2.0,<2.3"
+        python -m pip install --no-build-isolation -c ci/constraints-lowest.txt -e .[test]
         
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,12 +7,16 @@ on: [pull_request]
 
 jobs:
   build:
-  
+    name: Python ${{ matrix.python-version }} (${{ matrix.dependency-set }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        dependency-set: [highest]
+        include:
+          - python-version: '3.10'
+            dependency-set: lowest
 
     steps:
     - name: Checkout repository with submodules
@@ -34,11 +38,12 @@ jobs:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements
-        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ matrix.dependency-set }}-${{ hashFiles('pyproject.toml', 'ci/constraints-lowest.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ matrix.dependency-set }}-
+          ${{ runner.os }}-py${{ matrix.python-version }}-pip-
           ${{ runner.os }}-
-    - name: Install dependencies and package
+    - name: Install system and build dependencies
       run: |
         # upgrade apt-get and install system dependencies
         sudo apt-get update
@@ -47,8 +52,15 @@ jobs:
         # upgrade pip and install build/lint tooling
         python -m pip install -U pip setuptools wheel packaging flake8
 
-        # install cosmic together with its test dependencies
+    - name: Install package with highest-compatible dependencies
+      if: matrix.dependency-set == 'highest'
+      run: |
         python -m pip install .[test]
+
+    - name: Install package with lowest direct dependencies
+      if: matrix.dependency-set == 'lowest'
+      run: |
+        python -m pip install -c ci/constraints-lowest.txt .[test]
         
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout repository with submodules
@@ -25,7 +25,7 @@ jobs:
         git submodule set-branch --branch develop src/cosmic/src/METISSE
         git submodule update --remote src/cosmic/src/METISSE
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip

--- a/ci/constraints-lowest.txt
+++ b/ci/constraints-lowest.txt
@@ -7,5 +7,5 @@ astropy==6.1.0
 matplotlib==3.9.0
 tables==3.10.1
 h5py==3.12.1
-schwimmbad==0.3.1
+schwimmbad==0.4.0
 tqdm==4.1

--- a/ci/constraints-lowest.txt
+++ b/ci/constraints-lowest.txt
@@ -1,0 +1,11 @@
+# Lowest supported direct runtime dependencies for the Python 3.10 floor job.
+# Transitive and test dependencies intentionally use their latest compatible versions.
+numpy==2.0.0
+scipy==1.14.1
+pandas==2.2.3
+astropy==6.1.0
+matplotlib==3.9.0
+tables==3.10.1
+h5py==3.12.1
+schwimmbad==0.3.1
+tqdm==4.1

--- a/docs/pages/tutorials/adaptive/basics.rst
+++ b/docs/pages/tutorials/adaptive/basics.rst
@@ -198,7 +198,7 @@ These functions focus on double compact objects (DCOs) and are suitable for grav
 
 .. note::
 
-    The ``merging_dco`` function requires the `LEGWORK python package <https://legwork.readthedocs.io/en/latest/>`_ to compute the merger time.  If you do not have LEGWORK installed, ``merging_dco`` will raise an error.
+    The ``merging_dco`` function requires the `LEGWORK python package <https://legwork.readthedocs.io/en/latest/>`_ to compute the merger time.  If you do not have LEGWORK installed, ``merging_dco`` will raise an error. It can be installed using ``pip install cosmic-popsynth[merging-dco]``
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,15 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "numpy >= 2.0, < 2.3",          # if you change numpy versions, also change it in (1) the build-system section below and (2) the .github/workflows/build_wheels_and_publish.yml file
-    "scipy >= 1.14.1, <1.16",
+    "numpy >= 2.0, < 2.6",          # if you change numpy versions, also change it in the build-system section below
+    "scipy >= 1.14.1, < 1.19",
     "pandas >= 2.2.3, < 3.1",
     "astropy >= 6.1, < 9.0",
     "matplotlib >= 3.9, < 4.0",
     "tables >= 3.10.1, < 4.0",
-    "h5py >= 3.12.0, < 4.0",
+    "h5py >= 3.12.1, < 4.0",
     "schwimmbad >= 0.3.1",
-    "tqdm >= 4.0",
+    "tqdm >= 4.1",
     "configparser",
 ]
 
@@ -62,7 +62,25 @@ all = ["cosmic-popsynth[doc, test, merging_dco]"]
 
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python>=0.15', 'meson>=1.3', 'numpy >= 2.0, < 2.3', 'ninja']
+requires = [
+    'meson-python>=0.15',
+    'meson>=1.3',
+    'ninja',
+    # numpy < 2.3 does not support Python 3.14, and numpy >= 2.3.2 (the
+    # first release with cp314 wheels) publishes manylinux_2_28 wheels only.
+    "numpy >= 2.0, < 2.3; python_version < '3.14'",
+    "numpy >= 2.3.2, < 2.6;      python_version >= '3.14'",
+]
+
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+
+# cp314 has to build against numpy >= 2.3.2, which ships manylinux_2_28 wheels only.
+# Everything else stays on manylinux2014 (glibc 2.17) so the existing wheels keep
+# working on older systems.
+[[tool.cibuildwheel.overrides]]
+select = "cp314-*"
+manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ doc = [
     "sphinx-design",
     "sphinx-copybutton",
     "sphinx-gallery",
+    "beautifulsoup4",
 ]
 test = [
     "pytest",
@@ -54,8 +55,10 @@ test = [
     "coverage",
     "importlib-metadata < 5.0",
     "wheel",
+    "dill",
 ]
-all = ["cosmic-popsynth[doc, test]"]
+merging_dco = ["legwork"]
+all = ["cosmic-popsynth[doc, test, merging_dco]"]
 
 [build-system]
 build-backend = 'mesonpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,10 @@ dependencies = [
     "matplotlib >= 3.9, < 4.0",
     "tables >= 3.10.1, < 4.0",
     "h5py >= 3.12.1, < 4.0",
-    "schwimmbad >= 0.3.1",
+    "schwimmbad >= 0.4.0",
     "tqdm >= 4.1",
     "configparser",
+    "dill",
 ]
 
 [project.optional-dependencies]
@@ -53,12 +54,10 @@ test = [
     "pytest",
     "pytest-cov",
     "coverage",
-    "importlib-metadata < 5.0",
     "wheel",
-    "dill",
 ]
-merging_dco = ["legwork"]
-all = ["cosmic-popsynth[doc, test, merging_dco]"]
+merging-dco = ["legwork"]
+all = ["cosmic-popsynth[doc, test, merging-dco]"]
 
 [build-system]
 build-backend = 'mesonpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ requires = [
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
+before-test = "pip install \"numpy >= 2.0, < 2.3; python_version < '3.14'\" \"numpy >= 2.3.2, < 2.6; python_version >= '3.14'\""
+test-environment = { PIP_NO_DEPS = "1" }
+test-command = "python -c \"from cosmic import _evolvebin\""
 
 # cp314 has to build against numpy >= 2.3.2, which ships manylinux_2_28 wheels only.
 # Everything else stays on manylinux2014 (glibc 2.17) so the existing wheels keep
@@ -84,4 +87,3 @@ manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
-

--- a/src/cosmic/filter.py
+++ b/src/cosmic/filter.py
@@ -22,11 +22,9 @@
 import operator
 import token
 import re
+from io import StringIO
 from tokenize import generate_tokens
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import StringIO
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -197,10 +195,10 @@ def parse_column_filters(*definitions):
 
 def _flatten(container):
     """Flatten arbitrary nested list of filters into a 1-D list"""
-    if isinstance(container, string_types):
+    if isinstance(container, str):
         container = [container]
     for elem in container:
-        if isinstance(elem, string_types) or is_filter_tuple(elem):
+        if isinstance(elem, str) or is_filter_tuple(elem):
             yield elem
         else:
             for elem2 in _flatten(elem):
@@ -210,5 +208,5 @@ def _flatten(container):
 def is_filter_tuple(tup):
     """Return whether a `tuple` matches the format for a column filter"""
     return isinstance(tup, (tuple, list)) and (
-        len(tup) == 3 and isinstance(tup[0], string_types) and callable(tup[1])
+        len(tup) == 3 and isinstance(tup[0], str) and callable(tup[1])
     )

--- a/src/cosmic/meson.build
+++ b/src/cosmic/meson.build
@@ -18,6 +18,11 @@ py3.install_sources(
   subdir: 'cosmic'
 )
 
+py3.install_sources(
+  'data/__init__.py',
+  subdir: 'cosmic/data',
+)
+
 install_data(
   'data/cosmic-settings.json',
   install_dir: py3.get_install_dir() / 'cosmic' / 'data',

--- a/src/cosmic/sample/sampler/cmc.py
+++ b/src/cosmic/sample/sampler/cmc.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from .sampler import register_sampler
 from .independent import Sample
-from .. import InitialCMCTable, InitialBinaryTable
+from ..initialcmctable import InitialCMCTable
 from ..cmc import elson, king
 from ... import utils
 
@@ -414,5 +414,4 @@ class CMCSample(Sample):
         porb_max = utils.p_from_a(amax, mass1_binary, mass2_binary)
 
         return porb_max ## returns orbital period IN DAYS
-
 

--- a/src/cosmic/sample/sampler/independent.py
+++ b/src/cosmic/sample/sampler/independent.py
@@ -29,7 +29,7 @@ import os
 from cosmic import utils
 
 from .sampler import register_sampler
-from .. import InitialBinaryTable
+from ..initialbinarytable import InitialBinaryTable
 
 
 __author__ = "Katelyn Breivik <katie.breivik@gmail.com>"

--- a/src/cosmic/sample/sampler/multidim.py
+++ b/src/cosmic/sample/sampler/multidim.py
@@ -21,7 +21,7 @@
 from schwimmbad import MultiPool, MPIPool
 
 from .sampler import register_sampler
-from .. import InitialBinaryTable
+from ..initialbinarytable import InitialBinaryTable
 from ... import utils
 
 import numpy as np

--- a/src/cosmic/sample/sampler/sampler.py
+++ b/src/cosmic/sample/sampler/sampler.py
@@ -21,8 +21,6 @@
 
 import re
 
-from six import string_types
-
 from astropy.io.registry import IORegistryError
 from astropy.table import Table
 
@@ -92,7 +90,7 @@ def _update__doc__(data_class):
     sampler = data_class.sampler
 
     # if __doc__ isn't a string, bail-out now
-    if not isinstance(sampler.__doc__, string_types):
+    if not isinstance(sampler.__doc__, str):
         return
 
     # remove the old format list

--- a/src/cosmic/sample/stroopwafel/presets.py
+++ b/src/cosmic/sample/stroopwafel/presets.py
@@ -31,7 +31,7 @@ def merging_dco(kstar_1, kstar_2, max_merge_time=13.7):
         from legwork import evol
     except ImportError:
         raise ImportError("The 'merging_dco' preset requires the LEGWORK package. "
-                          "Please install it with 'pip install legwork' to use this preset.")
+                          "Please install it with 'pip install cosmic-popsynth[merging-dco]' to use this preset.")
     import astropy.units as u
 
     k1_set = set(kstar_1)

--- a/src/cosmic/tests/meson.build
+++ b/src/cosmic/tests/meson.build
@@ -4,7 +4,8 @@ python_sources = [
   'test_match.py',
   'test_sample.py',
   'test_stroopwafel.py',
-  'test_utils.py'
+  'test_utils.py',
+  'test_compatibility.py',
 ]
 
 py3.install_sources(

--- a/src/cosmic/tests/test_compatibility.py
+++ b/src/cosmic/tests/test_compatibility.py
@@ -1,0 +1,100 @@
+"""Focused regression tests for modern-Python compatibility paths."""
+
+import operator
+import sys
+
+import pytest
+
+from cosmic import utils
+from cosmic.filter import parse_column_filters
+from cosmic.sample.sampler import sampler as sampler_registry
+from cosmic.sample.stroopwafel.presets import merging_dco
+
+
+def test_parse_column_filters_flattens_nested_definitions():
+    preset = ("mass_2", operator.lt, 5.0)
+
+    result = parse_column_filters(
+        [["mass_1 >= 8"], [preset]],
+        "ecc < 0.9",
+    )
+
+    assert result == [
+        ("mass_1", operator.ge, 8.0),
+        preset,
+        ("ecc", operator.lt, 0.9),
+    ]
+
+
+def test_parse_inifile_preserves_constant_types(tmp_path):
+    inifile = tmp_path / "constants.ini"
+    inifile.write_text(
+        """\
+[sse]
+stellar_engine = 'sse'
+
+[bse]
+integer = 7
+floating = 2.5
+enabled = True
+missing = None
+values = [1, 'two', False, None]
+expression = 2 + 3 * 4
+
+[rand_seed]
+seed = 42
+
+[filters]
+select_final_state = True
+
+[convergence]
+pop_select = formation
+
+[sampling]
+sampling_method = independent
+""",
+        encoding="utf-8",
+    )
+
+    bse, sse, seed, filters, convergence, sampling = utils.parse_inifile(inifile)
+
+    assert bse == {
+        "integer": 7,
+        "floating": 2.5,
+        "enabled": True,
+        "missing": None,
+        "values": [1, "two", False, None],
+        "expression": 14,
+    }
+    assert sse == {"stellar_engine": "sse"}
+    assert seed == 42
+    assert filters == {"select_final_state": True}
+    assert convergence == {"pop_select": "formation"}
+    assert sampling == {"sampling_method": "independent"}
+
+
+def test_register_sampler_accepts_docless_method(monkeypatch):
+    class DummyData:
+        def sampler(self):
+            pass
+
+    def sample():
+        return "sampled"
+
+    monkeypatch.setattr(sampler_registry, "_SAMPLERS", {})
+
+    sampler_registry.register_sampler("docless", DummyData, sample)
+
+    registered = sampler_registry.get_sampler("docless", DummyData)
+    assert registered is sample
+    assert registered() == "sampled"
+    assert DummyData.sampler.__doc__ is None
+
+
+def test_merging_dco_names_the_optional_dependency_group(monkeypatch):
+    # A None entry in sys.modules makes the import inside merging_dco fail the
+    # same way it does for a user who never installed the optional extra.
+    monkeypatch.setitem(sys.modules, "legwork", None)
+
+    with pytest.raises(ImportError, match=r"pip install cosmic-popsynth\[merging-dco\]"):
+        merging_dco(kstar_1=[14], kstar_2=[14])

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -35,11 +35,7 @@ from pathlib import Path
 import h5py as h5
 import re
 
-import sys
-if sys.version_info >= (3, 9):
-    from importlib.resources import files as io_files
-else:
-    from importlib_resources import files as io_files
+from importlib.resources import files as io_files
 
 from configparser import ConfigParser
 from .bse_utils.zcnsts import zcnsts

--- a/src/cosmic/utils.py
+++ b/src/cosmic/utils.py
@@ -1554,10 +1554,11 @@ def parse_inifile(inifile):
             """Different strings receive different evaluation"""
             if isinstance(node, ast.Expression):
                 return _eval(node.body)
-            elif isinstance(node, ast.Str):
-                return node.s
-            elif isinstance(node, ast.Num):
-                return node.n
+            elif isinstance(node, ast.Constant):
+                # strings, numbers and None/True/False all parse to Constant on
+                # Python 3.8+. The ast.Str/ast.Num/ast.NameConstant aliases this
+                # used to match on were removed in Python 3.14.
+                return node.value
             elif isinstance(node, ast.BinOp):
                 return binOps[type(node.op)](_eval(node.left), _eval(node.right))
             elif isinstance(node, ast.List):
@@ -1579,9 +1580,6 @@ def parse_inifile(inifile):
                 else:
                     # return special string like True or False
                     return value
-            elif isinstance(node, ast.NameConstant):
-                # None, True, False are nameconstants in python3, but names in 2
-                return node.value
             else:
                 raise Exception("Unsupported type {}".format(node))
 


### PR DESCRIPTION
Closes #825

## Summary
- Extend support for python to 3.14, numpy to 2.5, scipy to 1.18
- Make several undeclared dependencies explicit (`dill`, `beautifulsoup4`/`bs4`)
- Added an explicit `extras` optional dependency group for the optional `legwork`
- Docs update re: the `extras` optional dependency
- Remove obsolete python 2.x compatibility code (including `six`, `importlib_resources` dependency)
- Replace obsolete/deprecated AST node references
- Upgrade dependency floors to versions that exist on pypi (`h5py` and `tqdm`)
- Add `lowest` CI job
- Added smoke test to CI to ensure built wheels work
- Add Python 3.14 to test matrix
- Add `data/__init__.py` to meson so editable installs work
- Removed unused dependency `importlib-metadata < 5.0` from the `test` extra
- Bumped `schwimmbad` floor to `>=0.4.0`
- `cibuildwheel` config migrated from workflow env vars into `[tool.cibuildwheel]` in `pyproject.toml`
- `CIBW_SKIP` gained `*t-*`, making the exclusion of free-threaded wheels explicit — `CIBW_BUILD`'s `cp3XX-*` patterns already excluded them, since those globs don't match the `cp3XXt-*` identifiers; let me know if that is not intended.
- fix the broken coverage CI job
- add unit tests for every uncovered line touched
- Fixed a circular import chain and removed an unused circular import

Linux CPython 3.14 wheels need to use a different build environment (`manylinux_2_28`), but the old build environment (`manylinux2014`) can still be used for 3.13 and prior, because upgrading it would break backwards compatibility on legacy systems.

## Version floor compatibility issue
The `lowest` CI job would have used `schwimmbad==0.3.1`, which implicitly requires `setuptools<82` because `pkg_resources` is removed after that. However, there is currently no declared setuptools requirement in pyproject.toml, and adding a new explicit dependency requirement `setuptools<82` in pyproject.toml would likely break/unnecessarily constrain some existing more modern working builds. 

Instead, I bumped the version floor to `schwimmbad>=0.4.0` to remove the setuptools compatibility issue. 

Alternatively, the  `lowest` job could just pin `setuptools<82` without stating that as a requirement in pyproject.toml, which would work but create a minor risk that some users could accidentally have a non-functional install with a set of versions that was not prohibited by pyproject.toml.

Let me know if you prefer an alternate approach.

Note: this PR did not *cause* the issue, the addition of the `lowest` CI job *detected* an existing issue with the declared dependency contract, which is its purpose.

## Coverage CI job fix
I noticed that the coverage CI is comparing every new PR to a 3 year old commit before the switch to `meson`, so it *always* fails. I added a fix (upload the coverage report on push to `develop`), which should hit on future PRs or reruns *after this PR is merged*; until then it will still be broken. The coverage job was also always reporting 0% for every single non-test python file due to the `src` tree, which should also be fixed now. 

The 0% came from installing non-editable; --cov=./src/cosmic measured a source tree that never executed. That requires --no-build-isolation (and preinstalling the build deps), because meson-python bakes the ninja path from pip's ephemeral build environment into the editable loader, and that directory is deleted after install — the first import cosmic would otherwise fail with FileNotFoundError.

## Packaging Note
Note that, currently, meson builds all of the tests *into the wheel at package root*, e.g. `cosmic/test_compatibility.py`, rather than `cosmic/tests/test_compatibility.py` or simply not building the tests into the installable wheel. I didn't change that because don't know if that is on purpose for some reason, but if you don't want to build the tests into the wheel, say so and I can make meson not build the tests into the wheel or at least build them into `cosmic/tests`.

## AI Use Disclosure
The fixes were a mix of manual work (inspecting dependency floors, finding unused or undeclared dependencies, deciding to add new CI jobs) and fixes guided by Codex GPT-5.6 Sol. The changes were cross-reviewed by Claude Opus 5.0 and a separate Codex GPT-5.6 Sol agent. I reviewed all the changes. 
